### PR TITLE
Extract boss level from tweet

### DIFF
--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -113,6 +113,7 @@ class WebSocketRaidFinderClient(
   }
 
   override def onWebSocketMessage(message: Response): Unit = message match {
+    // TODO: Exclude old bosses
     case r: RaidBossesResponse =>
       r.raidBosses.foreach { raidBoss =>
         val bossName = raidBoss.name
@@ -121,7 +122,7 @@ class WebSocketRaidFinderClient(
           case None =>
             val newColumn = RaidBossColumn(raidBoss = Var(raidBoss), raidTweets = Vars.empty)
             allBossesMap = allBossesMap.updated(bossName, newColumn)
-            state.allBosses.get := allBossesMap.values
+            state.allBosses.get := allBossesMap.values.toArray.sortBy(_.raidBoss.get.level)
 
           // Update existing raid boss data
           case Some(column) => column.raidBoss := raidBoss

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -40,7 +40,7 @@ class WebSocketRaidFinderClient(
   Option(storage.getItem(followedBossesStorageKey)).foreach(_.split(",").foreach(follow))
 
   private def updateLocalStorage(): Unit = {
-    val bossNames = state.followedBosses.get.map(_.raidBoss.get.bossName)
+    val bossNames = state.followedBosses.get.map(_.raidBoss.get.name)
     if (bossNames.isEmpty)
       storage.removeItem(followedBossesStorageKey)
     else
@@ -53,7 +53,7 @@ class WebSocketRaidFinderClient(
 
   /** Get the column number associated with a raid boss */
   private def columnIndex(bossName: BossName): Option[Int] = {
-    val index = state.followedBosses.get.indexWhere(_.raidBoss.get.bossName == bossName)
+    val index = state.followedBosses.get.indexWhere(_.raidBoss.get.name == bossName)
     if (index < 0) None else Some(index)
   }
 
@@ -115,7 +115,7 @@ class WebSocketRaidFinderClient(
   override def onWebSocketMessage(message: Response): Unit = message match {
     case r: RaidBossesResponse =>
       r.raidBosses.foreach { raidBoss =>
-        val bossName = raidBoss.bossName
+        val bossName = raidBoss.name
         allBossesMap.get(bossName) match {
           // New raid boss that we don't yet know about
           case None =>
@@ -144,7 +144,7 @@ object RaidFinderClient {
 
   object RaidBossColumn {
     def empty(bossName: BossName): RaidBossColumn = {
-      val raidBoss = RaidBoss(bossName = bossName)
+      val raidBoss = RaidBoss(name = bossName)
       RaidBossColumn(raidBoss = Var(raidBoss), raidTweets = Vars.empty)
     }
   }
@@ -154,7 +154,7 @@ object RaidFinderClient {
     followedBosses: Vars[RaidBossColumn]
   ) {
     lazy val followedBossNames: Binding[Set[BossName]] = Binding {
-      followedBosses.bind.map(_.raidBoss.get.bossName).toSet
+      followedBosses.bind.map(_.raidBoss.get.name).toSet
     }
   }
 }

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
@@ -55,7 +55,7 @@ object BossSelectorDialog {
           val boss = bossColumn.raidBoss.bind
           val isFollowing = client.state.followedBossNames.bind
           val smallImage = boss.image.map(_ + ":thumb")
-          bossListItem(boss.bossName, smallImage, isFollowing(boss.bossName)).bind
+          bossListItem(boss.name, smallImage, isFollowing(boss.name)).bind
         }
       }
     </ul>

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
@@ -50,7 +50,6 @@ object BossSelectorDialog {
   def bossList(client: RaidFinderClient): Binding[HTMLUListElement] = {
     <ul class="mdl-list" style="padding: 0; margin: 0;">
       {
-        // TODO: Sort bosses by level
         client.state.allBosses.map { bossColumn =>
           val boss = bossColumn.raidBoss.bind
           val isFollowing = client.state.followedBossNames.bind

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/RaidTweets.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/RaidTweets.scala
@@ -96,12 +96,12 @@ object RaidTweets {
   def raidBossHeader(raidBoss: RaidBoss, client: RaidFinderClient): Binding[HTMLElement] = {
     val headerRow =
       <div class="mdl-layout__header-row gbfrf-column__header-row">
-        <div class="mdl-layout-title gbfrf-column__header">{ raidBoss.bossName }</div>
+        <div class="mdl-layout-title gbfrf-column__header">{ raidBoss.name }</div>
         <div class="mdl-layout-spacer"></div>
-        <button class="mdl-button mdl-js-button mdl-button--icon" id={ menuId(raidBoss.bossName) }>
+        <button class="mdl-button mdl-js-button mdl-button--icon" id={ menuId(raidBoss.name) }>
           <i class="material-icons">more_vert</i>
         </button>
-        { raidBossHeaderMenu(raidBoss.bossName, client).bind }
+        { raidBossHeaderMenu(raidBoss.name, client).bind }
       </div>
 
     raidBoss.image.foreach(image => headerRow.backgroundImage(image + ":thumb", 0.25))

--- a/core/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
+++ b/core/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
@@ -31,7 +31,7 @@ class KnownBossesObserver(implicit ec: ExecutionContext) extends Observer[RaidIn
   def onError(e: Throwable): Unit = ()
   def onNext(elem: RaidInfo): Future[Ack] = {
     val name = elem.tweet.bossName
-    val raidBoss = RaidBoss.fromRaidInfo(elem)
+    val raidBoss = elem.boss
     agent.alter(_.updated(name, raidBoss)).flatMap(_ => Ack.Continue)
   }
 

--- a/core/src/main/scala/walfie/gbf/raidfinder/domain/package.scala
+++ b/core/src/main/scala/walfie/gbf/raidfinder/domain/package.scala
@@ -11,7 +11,7 @@ package object domain {
 package domain {
   case class RaidInfo(
     tweet: RaidTweet,
-    image: Option[RaidImage]
+    boss:  RaidBoss
   )
 
   case class RaidTweet(
@@ -25,17 +25,10 @@ package domain {
   )
 
   case class RaidBoss(
-    bossName: BossName,
+    name:     BossName,
+    level:    Int,
     image:    Option[RaidImage],
     lastSeen: Date
   )
-
-  object RaidBoss {
-    def fromRaidInfo(raidInfo: RaidInfo): RaidBoss = RaidBoss(
-      bossName = raidInfo.tweet.bossName,
-      image = raidInfo.image,
-      lastSeen = raidInfo.tweet.createdAt
-    )
-  }
 }
 

--- a/core/src/test/scala/walfie/gbf/raidfinder/KnownBossesObserverSpec.scala
+++ b/core/src/test/scala/walfie/gbf/raidfinder/KnownBossesObserverSpec.scala
@@ -30,7 +30,7 @@ class KnownBossesObserverSpec extends KnownBossesObserverSpecHelpers {
     observer.get shouldBe Map(
       "A" -> bosses1.last,
       "B" -> bosses2.last
-    ).mapValues(RaidBoss.fromRaidInfo)
+    ).mapValues(_.boss)
     cancelable.cancel()
   }
 }
@@ -46,7 +46,8 @@ trait KnownBossesObserverSpecHelpers extends FreeSpec with MockitoSugar with Eve
     val tweet = mock[RaidTweet]
     when(tweet.bossName) thenReturn bossName
     when(tweet.createdAt) thenReturn (new Date(Random.nextLong.abs * 1000))
-    RaidInfo(tweet, None)
+    val boss = mock[RaidBoss]
+    RaidInfo(tweet, boss)
   }
 }
 

--- a/core/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/core/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -21,10 +21,15 @@ class StatusParserSpec extends StatusParserSpecHelpers {
       createdAt = now
     )
 
-    val expectedImageUrl = "http://example.com/raid-image.png"
+    val expectedRaidBoss = RaidBoss(
+      name = "Lv60 Ozorotter",
+      level = 60,
+      image = Some("http://example.com/raid-image.png"),
+      lastSeen = now
+    )
 
     StatusParser.parse(mockStatus()) shouldBe Some {
-      RaidInfo(expectedRaidTweet, Some(expectedImageUrl))
+      RaidInfo(expectedRaidTweet, expectedRaidBoss)
     }
   }
 
@@ -43,7 +48,7 @@ class StatusParserSpec extends StatusParserSpecHelpers {
 
     val parsed = StatusParser.parse(status)
     parsed should not be empty
-    parsed.get.image shouldBe empty
+    parsed.foreach(_.boss.image shouldBe empty)
   }
 
   "return None if non-official client" in {

--- a/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/domain.proto
+++ b/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/domain.proto
@@ -12,7 +12,7 @@ option (scalapb.options) = {
 };
 
 message RaidBoss {
-  string bossName = 1;
+  string name = 1;
   google.protobuf.StringValue image = 2;
   int64 lastSeen = 3 [(scalapb.field).type = "java.util.Date"];
   int32 level = 4;

--- a/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/domain.proto
+++ b/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/domain.proto
@@ -15,5 +15,6 @@ message RaidBoss {
   string bossName = 1;
   google.protobuf.StringValue image = 2;
   int64 lastSeen = 3 [(scalapb.field).type = "java.util.Date"];
+  int32 level = 4;
 }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -23,7 +23,7 @@ class WebsocketRaidsHandler(out: ActorRef, raidFinder: RaidFinder) extends Actor
     case r: RaidBossesRequest =>
       val bosses = raidFinder.getKnownBosses.values.map { rb: RaidBoss =>
         protocol.RaidBoss(
-          bossName = rb.name,
+          name = rb.name,
           level = rb.level,
           image = rb.image,
           lastSeen = rb.lastSeen

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -23,7 +23,8 @@ class WebsocketRaidsHandler(out: ActorRef, raidFinder: RaidFinder) extends Actor
     case r: RaidBossesRequest =>
       val bosses = raidFinder.getKnownBosses.values.map { rb: RaidBoss =>
         protocol.RaidBoss(
-          bossName = rb.bossName,
+          bossName = rb.name,
+          level = rb.level,
           image = rb.image,
           lastSeen = rb.lastSeen
         )


### PR DESCRIPTION
- Parse boss level from tweet, include in `RaidBoss`
- Rename `bossName` to `name`
- Sort bosses by level/name
