### PR TITLE
Support English tweets

### DIFF
--- a/core/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/core/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -15,7 +15,7 @@ trait RaidFinder {
 
 object RaidFinder {
   val DefaultCacheSizePerBoss = 20
-  val DefaultBacklogSize = 100
+  val DefaultBacklogSize = 200
 
   /** Stream tweets without looking up old tweets first */
   def withoutBacklog(

--- a/core/src/main/scala/walfie/gbf/raidfinder/TwitterSearcher.scala
+++ b/core/src/main/scala/walfie/gbf/raidfinder/TwitterSearcher.scala
@@ -28,7 +28,7 @@ object TwitterSearcher {
 
   /** The maximum number of search results returned from the twitter API is 100 */
   val MaxCount = 100
-  val DefaultSearchTerm = "参加者募集！参戦ID："
+  val DefaultSearchTerm = "参加者募集！参戦ID： OR \"I need backup!\""
 
   def apply(twitter: Twitter, paginationType: PaginationType): Twitter4jSearcher =
     new Twitter4jSearcher(twitter, paginationType)

--- a/core/src/main/scala/walfie/gbf/raidfinder/TwitterStreamer.scala
+++ b/core/src/main/scala/walfie/gbf/raidfinder/TwitterStreamer.scala
@@ -11,7 +11,10 @@ trait TwitterStreamer {
 }
 
 object TwitterStreamer {
-  val DefaultFilterTerms = (15 to 150 by 5).map("Lv" + _)
+  // For English tweets, we can just search "I need backup!"
+  // For Japanese tweets we can't just use "参加者募集！" since words must be
+  // space-separated, and the only space-separated thing is the boss level.
+  val DefaultFilterTerms = (15 to 150 by 5).map("Lv" + _) :+ "I need backup!"
 
   def apply(
     twitterStream: twitter4j.TwitterStream = TwitterStreamFactory.getSingleton,

--- a/core/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/core/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -10,11 +10,11 @@ import twitter4j._
 import walfie.gbf.raidfinder.domain._
 
 class StatusParserSpec extends StatusParserSpecHelpers {
-  "parse a valid status" in {
+  "parse a valid status in Japanese" in {
     val expectedRaidTweet = RaidTweet(
       tweetId = 12345L,
       screenName = "walfieee",
-      bossName = "Lv60 Ozorotter",
+      bossName = "Lv60 オオゾラッコ",
       raidId = "ABCD1234",
       profileImage = "http://example.com/profile-image_normal.png",
       text = "INSERT CUSTOM MESSAGE HERE",
@@ -22,7 +22,7 @@ class StatusParserSpec extends StatusParserSpecHelpers {
     )
 
     val expectedRaidBoss = RaidBoss(
-      name = "Lv60 Ozorotter",
+      name = "Lv60 オオゾラッコ",
       level = 60,
       image = Some("http://example.com/raid-image.png"),
       lastSeen = now
@@ -33,11 +33,39 @@ class StatusParserSpec extends StatusParserSpecHelpers {
     }
   }
 
+  "parse a valid status in English" in {
+    val expectedRaidTweet = RaidTweet(
+      tweetId = 12345L,
+      screenName = "walfieee",
+      bossName = "Lvl 60 Ozorotter",
+      raidId = "ABCD1234",
+      profileImage = "http://example.com/profile-image_normal.png",
+      text = "INSERT CUSTOM MESSAGE HERE",
+      createdAt = now
+    )
+
+    val expectedRaidBoss = RaidBoss(
+      name = "Lvl 60 Ozorotter",
+      level = 60,
+      image = Some("http://example.com/raid-image.png"),
+      lastSeen = now
+    )
+
+    val text = """
+      |INSERT CUSTOM MESSAGE HERE I need backup!Battle ID: ABCD1234
+      |Lvl 60 Ozorotter""".stripMargin.trim
+    val status = mockStatus(text = text)
+
+    StatusParser.parse(status) shouldBe Some {
+      RaidInfo(expectedRaidTweet, expectedRaidBoss)
+    }
+  }
+
   "parse a status without an image URL at the end" in {
     // New bosses (e.g., watermelon boss) might not have images when they first come out
     val text = """
       |INSERT CUSTOM MESSAGE HERE 参加者募集！参戦ID：ABCD1234
-      |Lv60 Ozorotter""".stripMargin.trim
+      |Lv60 オオゾラッコ""".stripMargin.trim
     val status = mockStatus(text = text)
 
     StatusParser.parse(status) should not be empty
@@ -66,7 +94,7 @@ trait StatusParserSpecHelpers extends FreeSpec with MockitoSugar {
 
   val validTweetText = """
     |INSERT CUSTOM MESSAGE HERE 参加者募集！参戦ID：ABCD1234
-    |Lv60 Ozorotter
+    |Lv60 オオゾラッコ
     |http://example.com/image-that-is-ignored.png""".stripMargin.trim
 
   def mockStatus(


### PR DESCRIPTION
Includes English tweets in stream/search. When parsing the tweet,
will attempt Japanese, then English. Since the grouping is done by name,
English boss tweets will have separate columns from Japanese ones,
since there's no easy way to programmatically connect the two.
Aside from maybe image processing, but that's some complex stuff.

Fixes #3.
