### PR TITLE
Fix Firefox styling issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,12 +49,16 @@ lazy val client = (project in file("client"))
       "org.scala-js" %%% "scalajs-dom" % "0.9.1",
       "com.thoughtworks.binding" %%% "dom" % "9.0.0",
       "org.webjars.npm" % "moment" % Versions.MomentJS,
+      "org.webjars.bower" % "dialog-polyfill" % Versions.DialogPolyfillJS,
       compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     ),
     jsDependencies ++= Seq(
       "org.webjars.npm" % "moment" % Versions.MomentJS
-        /        s"${Versions.MomentJS}/moment.js"
-        minified "min/moment.min.js"
+        / s"${Versions.MomentJS}/moment.js"
+        minified "min/moment.min.js",
+
+      "org.webjars.bower" % "dialog-polyfill" % Versions.DialogPolyfillJS
+        / s"${Versions.DialogPolyfillJS}/dialog-polyfill.js"
     )
   )
   .dependsOn(protocolJS)

--- a/client/src/main/resources/index.html
+++ b/client/src/main/resources/index.html
@@ -14,7 +14,6 @@
   <link rel="stylesheet" href="https://code.getmdl.io/1.2.0/material.indigo-pink.min.css">
   <link rel="stylesheet" href="style.css">
   <script defer src="https://code.getmdl.io/1.2.0/material.min.js"></script>
-  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.4/dialog-polyfill.min.js"></script>
 </body>
 </html>
 

--- a/client/src/main/resources/style.css
+++ b/client/src/main/resources/style.css
@@ -5,6 +5,8 @@ html, body {
 
 .gbfrf-main-content {
   height: 100%;
+  background: #ffffff;
+  position: relative;
 }
 
 .gbfrf-settings-fab__container {
@@ -33,7 +35,7 @@ html, body {
 
 @media (max-width: 460px) {
   .gbfrf-column {
-    width: 95%;
+    width: 90%;
   }
 }
 
@@ -45,7 +47,7 @@ html, body {
 
 .gbfrf-column__header-row {
   padding: 20px !important;
-  background-position-y: 20%;
+  background-position: 0 20%;
   background-size: 100% !important;
 }
 
@@ -136,6 +138,15 @@ html, body {
   height: 80%;
   width: 400px !important;
   padding: 0;
+  background: #ffffff;
+
+  position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .gbfrf-follow {
@@ -154,7 +165,7 @@ html, body {
   margin: 5px;
   background-color: #444;
   background-size: 100%;
-  background-position-y: 20%;
+  background-position: 0 20%;
   height: 50px;
 }
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/syntax/package.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/syntax/package.scala
@@ -24,10 +24,7 @@ package object syntax {
     def backgroundImage(imageUrl: String, opacity: Double): T = {
       val img = dom.document.createElement("img").asInstanceOf[HTMLImageElement]
       val color = s"rgba(0, 0, 0, $opacity)"
-      img.setAttribute("src", imageUrl)
-      img.onload = { _: dom.Event =>
-        elem.style.backgroundImage = s"linear-gradient($color, $color), url('$imageUrl')"
-      }
+      elem.style.backgroundImage = s"linear-gradient($color, $color), url('$imageUrl')"
       elem
     }
   }

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/BossSelectorDialog.scala
@@ -16,6 +16,7 @@ object BossSelectorDialog {
     val dialog = dom.document.createElement("dialog")
     dialog.classList.add("mdl-dialog")
     dialog.classList.add("gbfrf-follow__dialog")
+    js.Dynamic.global.dialogPolyfill.registerDialog(dialog)
     val closeModal = { (e: Event) => dialog.asInstanceOf[js.Dynamic].close(); () }
 
     val bossListElement = bossList(client).bind

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
@@ -3,6 +3,7 @@ package walfie.gbf.raidfinder.client.views
 import com.thoughtworks.binding
 import com.thoughtworks.binding.Binding
 import com.thoughtworks.binding.Binding._
+import org.scalajs.dom
 import org.scalajs.dom.raw._
 import scala.scalajs.js
 import walfie.gbf.raidfinder.client._
@@ -14,21 +15,29 @@ object MainContent {
     client:       RaidFinderClient,
     notification: Notification,
     currentTime:  Binding[Double]
-  ): Binding[HTMLDivElement] = {
-    val dialog = Binding(BossSelectorDialog.dialogElement(client).bind)
+  ): Binding[Node] = {
+    val dialog = Binding(BossSelectorDialog.dialogElement(client).bind).bind
 
-    <div class="gbfrf-main-content">
-      { notification.binding.bind }
-      { dialog.bind }
-      { floatingActionButton(dialog.bind, client).bind }
-      <div class="gbfrf-columns">
-        {
-          client.state.followedBosses.map { column =>
-            RaidTweets.raidTweetColumn(column.raidBoss, column.raidTweets, currentTime, client, notification).bind
+    val holder = dom.document.createDocumentFragment()
+
+    holder.appendChild(dialog)
+
+    val main =
+      <div class="gbfrf-main-content">
+        { notification.binding.bind }
+        { floatingActionButton(dialog, client).bind }
+        <div class="gbfrf-columns">
+          {
+            client.state.followedBosses.map { column =>
+              RaidTweets.raidTweetColumn(column.raidBoss, column.raidTweets, currentTime, client, notification).bind
+            }
           }
-        }
+        </div>
       </div>
-    </div>
+
+    holder.appendChild(main)
+
+    holder
   }
 
   @binding.dom

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,12 +1,15 @@
 object Versions {
   val Akka = "2.4.9"
   val Mockito = "1.10.19"
-  val MomentJS = "2.14.1"
   val Monix = "2.0-RC13"
   val Play = "2.5.6"
   val ScalaPB = "0.5.39"
   val ScalaPB_json4s = "0.1.1"
   val ScalaTest = "3.0.0"
   val Twitter4j = "4.0.4"
+
+  // JS Dependencies
+  val DialogPolyfillJS = "0.4.3"
+  val MomentJS = "2.14.1"
 }
 


### PR DESCRIPTION
- Actually use dialog polyfill (pull from webjar this time)
- Move dialog element to be child of body element
- Replace background-position-y with background-position
- Add background and relative position to main content div

Other changes not necessarily related to FF compatibility:
- Reduce column size on small screens
- Don't load background images in an img tag

Fixes #20.
