### PR TITLE
Get info about followed bosses on reconnect

### DIFF
--- a/client/src/main/resources/index.html
+++ b/client/src/main/resources/index.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Granblue Raid Finder</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link rel="stylesheet" href="https://code.getmdl.io/1.2.0/material.indigo-pink.min.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <script src="../gbf-raidfinder-client-jsdeps.js"></script>
   <script src="../gbf-raidfinder-client-fastopt.js"></script>
   <script src="../gbf-raidfinder-client-launcher.js"></script>
 
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://code.getmdl.io/1.2.0/material.indigo-pink.min.css">
-  <link rel="stylesheet" href="style.css">
   <script defer src="https://code.getmdl.io/1.2.0/material.min.js"></script>
 </body>
 </html>

--- a/client/src/main/resources/style.css
+++ b/client/src/main/resources/style.css
@@ -206,6 +206,18 @@ html, body {
   flex-direction: column;
 }
 
+.gbfrf-settings__footer {
+  margin-top: auto;
+  align-self: flex-end;
+  padding: 5px;
+  color: gray;
+}
+
+.gbfrf-settings__footer a {
+  text-decoration: none;
+  color: gray;
+}
+
 .gbfrf-settings__item {
   border-bottom: 1px solid gray;
 }

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
@@ -23,7 +23,6 @@ object Application extends JSApp {
     val client = new WebSocketRaidFinderClient(
       websocket, dom.window.localStorage, bossTtl, SystemClock
     )
-    client.updateAllBosses()
 
     Moment.defineLocale("en-short", MomentShortLocale)
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
@@ -23,7 +23,7 @@ object Application extends JSApp {
     val client = new WebSocketRaidFinderClient(
       websocket, dom.window.localStorage, bossTtl, SystemClock
     )
-    client.updateBosses()
+    client.updateAllBosses()
 
     Moment.defineLocale("en-short", MomentShortLocale)
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -14,7 +14,8 @@ import walfie.gbf.raidfinder.protocol._
 trait RaidFinderClient {
   def state: RaidFinderClient.State
 
-  def updateBosses(): Unit
+  def updateBosses(bossNames: Seq[BossName]): Unit
+  def updateAllBosses(): Unit
   def follow(bossName: BossName): Unit
   def unfollow(bossName: BossName): Unit
   def clear(bossName: BossName): Unit
@@ -63,9 +64,10 @@ class WebSocketRaidFinderClient(
       storage.setItem(followedBossesStorageKey, bossNames.mkString(","))
   }
 
-  def updateBosses(): Unit = {
-    websocket.send(RaidBossesRequest())
-  }
+  def updateBosses(bossNames: Seq[BossName]): Unit =
+    websocket.send(RaidBossesRequest(bossNames))
+  def updateAllBosses(): Unit =
+    websocket.send(AllRaidBossesRequest())
 
   /** Get the column number associated with a raid boss */
   private def columnIndex(bossName: BossName): Option[Int] = {

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/WebSocketClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/WebSocketClient.scala
@@ -5,7 +5,7 @@ import org.scalajs.dom
 import scala.scalajs.js
 import walfie.gbf.raidfinder.client.util.time.Duration
 import walfie.gbf.raidfinder.protocol._
-import walfie.gbf.raidfinder.protocol.implicits._
+import walfie.gbf.raidfinder.protocol.syntax._
 
 import js.ArrayOps
 import js.JSConverters._

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
@@ -53,7 +53,7 @@ object MainContent {
     currentTab: Binding[DialogTab]
   ): Binding[HTMLDivElement] = {
     val showModal = { e: Event =>
-      client.updateBosses()
+      client.updateAllBosses()
       dialog.asInstanceOf[js.Dynamic].showModal()
     }
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/SettingsMenu.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/SettingsMenu.scala
@@ -39,9 +39,19 @@ object SettingsMenu {
             }.bind
           }
         </ul>
-        <div style="margin-top: auto; align-self: flex-end; padding: 5px; color: gray;">github.com/walfie/gbf-raidfinder</div>
+        { footer.bind }
       </div>
     </section>
+  }
+
+  @binding.dom
+  def footer: Binding[HTMLDivElement] = {
+    // TODO: Don't hardcode this
+    <div class="gbfrf-settings__footer">
+      <a href="http://github.com/walfie/gbf-raidfinder" target="_blank">
+        github.com/walfie/gbf-raidfinder
+      </a>
+    </div>
   }
 
   @binding.dom

--- a/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/requests.proto
+++ b/protocol/src/main/protobuf/walfie/gbf/raidfinder/protocol/requests.proto
@@ -11,14 +11,21 @@ option (scalapb.options) = {
 
 message RequestMessage {
   oneof data {
-    RaidBossesRequest raidBossesMessage = 1;
-    FollowRequest followMessage = 2;
-    UnfollowRequest unfollowMessage = 3;
+    AllRaidBossesRequest allRaidBossesMessage = 1;
+    RaidBossesRequest raidBossesMessage = 2;
+    FollowRequest followMessage = 3;
+    UnfollowRequest unfollowMessage = 4;
   };
+};
+
+message AllRaidBossesRequest {
+  option (scalapb.message).extends = "Request";
 };
 
 message RaidBossesRequest {
   option (scalapb.message).extends = "Request";
+
+  repeated string bossNames = 1;
 };
 
 message FollowRequest {

--- a/protocol/src/main/scala/walfie/gbf/raidfinder/protocol/syntax.scala
+++ b/protocol/src/main/scala/walfie/gbf/raidfinder/protocol/syntax.scala
@@ -1,13 +1,14 @@
 package walfie.gbf.raidfinder.protocol
 
 /** Convenience classes for dealing with Protobuf `oneof` messages */
-package object implicits {
+package object syntax {
   implicit class RequestMessageOps(val message: RequestMessage) extends AnyVal {
     import RequestMessage.Data._
 
     // Could also do `raidBossesMessage orElse followMessage orElse ...`
     // but it doesn't check for exhaustive matches, so we'll use this verbose way
     def toRequest(): Option[Request] = message.data match {
+      case AllRaidBossesMessage(v) => Some(v)
       case RaidBossesMessage(v) => Some(v)
       case FollowMessage(v) => Some(v)
       case UnfollowMessage(v) => Some(v)
@@ -20,6 +21,7 @@ package object implicits {
 
     def toMessage(): RequestMessage = {
       val data = request match {
+        case v: AllRaidBossesRequest => AllRaidBossesMessage(v)
         case v: RaidBossesRequest => RaidBossesMessage(v)
         case v: FollowRequest => FollowMessage(v)
         case v: UnfollowRequest => UnfollowMessage(v)


### PR DESCRIPTION
Split the `RaidBossesRequest` into two (one for all bosses, one for a
specific list of bosses). On reconnect, get info for the currently-
followed bosses.
