### PR TITLE
Enable gzip compression on server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val server = (project in file("server"))
     name := "gbf-raidfinder-server",
     libraryDependencies ++= Seq(
       "com.trueaccord.scalapb" %% "scalapb-json4s" % Versions.ScalaPB_json4s,
+      "com.typesafe.play" %% "filters-helpers" % Versions.Play,
       "com.typesafe.play" %% "play-netty-server" % Versions.Play
     )
   )

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
@@ -8,14 +8,17 @@ import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
 import play.core.server._
+import play.filters.gzip.GzipFilterComponents
 import scala.concurrent.Future
 import walfie.gbf.raidfinder.RaidFinder
 import walfie.gbf.raidfinder.server.controller._
 
 class Components(val raidFinder: RaidFinder, port: Int) extends NettyServerComponents
-  with BuiltInComponents with Controller with RaidFinderControllers {
+  with BuiltInComponents with GzipFilterComponents with Controller with RaidFinderControllers {
 
   override lazy val serverConfig = ServerConfig(port = Some(port))
+
+  override lazy val httpFilters = List(gzipFilter)
 
   lazy val router = Router.from {
     case GET(p"/") => controllers.Assets.at(path = "/public", "index.html")


### PR DESCRIPTION
This brings the optimized JS down to ~125kB (compared to 650+kB) which
is much more acceptable. It's about the same size as Angular 2.
