### PR TITLE
Push new bosses to clients

### DIFF
--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -16,6 +16,7 @@ trait RaidFinderClient {
 
   def updateBosses(bossNames: Seq[BossName]): Unit
   def updateAllBosses(): Unit
+  def resetBossList(): Unit
   def follow(bossName: BossName): Unit
   def unfollow(bossName: BossName): Unit
   def toggleFollow(bossName: BossName): Unit
@@ -71,6 +72,13 @@ class WebSocketRaidFinderClient(
     websocket.send(RaidBossesRequest(bossNames))
   def updateAllBosses(): Unit =
     websocket.send(AllRaidBossesRequest())
+
+  def resetBossList(): Unit = {
+    val followed = state.followedBosses.get
+    state.allBosses.get := followed
+    allBossesMap = followed.map(column => column.raidBoss.get.name -> column).toMap
+    updateAllBosses()
+  }
 
   /** Get the column number associated with a raid boss */
   private def columnIndex(bossName: BossName): Option[Int] = {

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -43,12 +43,14 @@ class WebSocketRaidFinderClient(
     .foreach(_.split(",").foreach(follow))
 
   override def onWebSocketOpen(): Unit = {
-    refollowBosses()
-    updateAllBosses()
+    resetBossList()
     isConnected := true
   }
 
-  override def onWebSocketReconnect(): Unit = onWebSocketOpen()
+  override def onWebSocketReconnect(): Unit = {
+    refollowBosses()
+    isConnected := true
+  }
 
   override def onWebSocketClose(): Unit = {
     isConnected := false

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -160,7 +160,6 @@ class WebSocketRaidFinderClient(
     case r: KeepAliveResponse => // Ignore
   }
 
-  // TODO: Exclude old bosses
   private def handleRaidBossesResponse(
     raidBosses: Seq[RaidBoss]
   ): Unit = {

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -43,13 +43,11 @@ class WebSocketRaidFinderClient(
 
   override def onWebSocketOpen(): Unit = {
     refollowBosses()
+    updateAllBosses()
     isConnected := true
   }
 
-  override def onWebSocketReconnect(): Unit = {
-    refollowBosses()
-    isConnected := true
-  }
+  override def onWebSocketReconnect(): Unit = onWebSocketOpen()
 
   override def onWebSocketClose(): Unit = {
     isConnected := false

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/Dialog.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/Dialog.scala
@@ -24,6 +24,7 @@ object Dialog {
     }
 
     val closeModal = { (e: Event) => dynamicDialog.close(); () }
+    val reloadBosses = { (e: Event) => client.resetBossList() }
 
     val onTabChange = () => ViewModel.persistState(viewState)
 
@@ -35,7 +36,7 @@ object Dialog {
         { BossSelectMenu.content(client, closeModal, currentTab, viewState.imageQuality).bind }
         { SettingsMenu.content(client, viewState).bind }
         <hr style="margin: 0;"/>
-        { dialogFooter(onCancel = closeModal).bind }
+        { dialogFooter(viewState.currentTab, closeModal = closeModal, reloadBosses = reloadBosses).bind }
       </div>
 
     dialog.appendChild(inner)
@@ -62,9 +63,19 @@ object Dialog {
   }
 
   @binding.dom
-  def dialogFooter(onCancel: Event => Unit): Binding[HTMLDivElement] = {
+  def dialogFooter(
+    currentTab:   Binding[ViewModel.DialogTab],
+    closeModal:   Event => Unit,
+    reloadBosses: Event => Unit
+  ): Binding[HTMLDivElement] = {
     <div class="mdl-dialog__actions">
-      <button type="button" class="mdl-button" onclick={ onCancel }>Cancel</button>
+      <button type="button" class="mdl-button" onclick={ closeModal }>Cancel</button>
+      <button type="button" class={
+        "mdl-button".addIf(currentTab.bind != DialogTab.Follow, "is-hidden")
+      } onclick={ reloadBosses }>
+        <i class="material-icons">refresh</i>
+        Reload Bosses
+      </button>
     </div>
   }
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
@@ -52,10 +52,7 @@ object MainContent {
     client:     RaidFinderClient,
     currentTab: Binding[DialogTab]
   ): Binding[HTMLDivElement] = {
-    val showModal = { e: Event =>
-      client.updateAllBosses()
-      dialog.asInstanceOf[js.Dynamic].showModal()
-    }
+    val showModal = (e: Event) => dialog.asInstanceOf[js.Dynamic].showModal()
 
     <div class="gbfrf-settings-fab__container" onclick={ showModal }>
       <button class="mdl-button mdl-js-button mdl-button--fab mdl-js-ripple-effect mdl-button--primary">

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -36,14 +36,13 @@ object Application {
     if (mode == Mode.Dev) {
       Logger.info("Press ENTER to stop the application.")
       scala.io.StdIn.readLine()
+      Logger.info("Stopping application...")
       server.stop()
+      Logger.info("Application stopped.")
     }
 
     Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = {
-        Logger.info("Stopping application.")
-        server.stop()
-      }
+      override def run(): Unit = server.stop()
     })
   }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -17,6 +17,10 @@ class WebsocketRaidsHandler(
   implicit val scheduler = Scheduler(context.system.dispatcher)
 
   var followed: Map[BossName, Cancelable] = Map.empty
+  val newBossListener: Cancelable = raidFinder.newBossObservable.foreach { boss =>
+    val bosses = Seq(raidBossToProtocol(boss))
+    this push RaidBossesResponse(raidBosses = bosses)
+  }
 
   def receive: Receive = {
     case r: RequestMessage => r.toRequest.foreach(handleRequest)
@@ -77,7 +81,8 @@ class WebsocketRaidsHandler(
   }
 
   override def postStop(): Unit = {
-    followed.values.foreach(_.cancel)
+    newBossListener.cancel()
+    followed.values.foreach(_.cancel())
   }
 }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -32,7 +32,7 @@ class WebsocketRaidsHandler(
     name = rb.name, level = rb.level, image = rb.image, lastSeen = rb.lastSeen
   )
 
-  val keepAliveCancellable = keepAliveInterval.map { interval =>
+  val keepAliveCancelable = keepAliveInterval.map { interval =>
     context.system.scheduler.schedule(interval, interval) {
       this push KeepAliveResponse()
     }
@@ -82,6 +82,7 @@ class WebsocketRaidsHandler(
 
   override def postStop(): Unit = {
     newBossListener.cancel()
+    keepAliveCancelable.foreach(_.cancel())
     followed.values.foreach(_.cancel())
   }
 }

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -71,6 +71,7 @@ class DefaultRaidFinder(
     .publish
 
   // Whenever a new boss comes in, info gets published here
+  // TODO: Maybe add test?
   val newBossObservable = raidInfos.map(_.boss).publish
 
   private val (partitioner, partitionerCancelable) = CachedRaidTweetsPartitioner

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -81,12 +81,14 @@ class DefaultRaidFinder(
     .fromRaidInfoObservable(raidInfos)
 
   private val raidInfosCancelable = raidInfos.connect()
+  private val newBossCancelable = newBossObservable.connect()
 
   private val cancelable = Cancelable { () =>
     List(
       raidInfosCancelable,
       partitionerCancelable,
-      knownBossesCancelable
+      knownBossesCancelable,
+      newBossCancelable
     ).foreach(_.cancel)
     onShutdown()
   }

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -9,6 +9,7 @@ import walfie.gbf.raidfinder.domain._
 
 trait RaidFinder {
   def getRaidTweets(bossName: BossName): Observable[RaidTweet]
+  def newBossObservable: Observable[RaidBoss]
   def getKnownBosses(): Map[BossName, RaidBoss]
   def shutdown(): Unit
 }
@@ -68,6 +69,9 @@ class DefaultRaidFinder(
   private val raidInfos = statusesObservable
     .collect(Function.unlift(StatusParser.parse))
     .publish
+
+  // Whenever a new boss comes in, info gets published here
+  val newBossObservable = raidInfos.map(_.boss).publish
 
   private val (partitioner, partitionerCancelable) = CachedRaidTweetsPartitioner
     .fromUngroupedObservable(raidInfos.map(_.tweet), cacheSizePerBoss)


### PR DESCRIPTION
- Add "Reload Bosses" button to menu for manual refresh
- Stop updating bosses every time the menu is opened
- When new bosses are found, push them to the client

Closes #35 
