### PR TITLE
Fix bug where boss info was sent for every tweet

### DIFF
--- a/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
@@ -21,7 +21,7 @@ object KnownBossesObserver {
 }
 
 /**
-  * Takes incoming [[RaidInfo]]s and keeps the latest of each raid boss.
+  * Takes incoming `RaidInfo`s and keeps the latest of each raid boss.
   * This can be implemented trivially with [[Observable#scan]] but eh.
   */
 class KnownBossesObserver(implicit ec: ExecutionContext) extends Observer[RaidInfo] with KnownBossesMap {

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -72,7 +72,11 @@ class DefaultRaidFinder(
 
   // Whenever a new boss comes in, info gets published here
   // TODO: Maybe add test?
-  val newBossObservable = raidInfos.map(_.boss).publish
+  val newBossObservable = raidInfos
+    .map(_.boss)
+    .groupBy(_.name)
+    .flatMap(_.headF)
+    .publish
 
   private val (partitioner, partitionerCancelable) = CachedRaidTweetsPartitioner
     .fromUngroupedObservable(raidInfos.map(_.tweet), cacheSizePerBoss)


### PR DESCRIPTION
The `newBossObservable` should only emit items when a new boss is found.
The previous code would emit on every tweet.
