### PR TITLE
Periodically store known bosses in Redis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,12 @@ lazy val root = (project in file("."))
     herokuAppName in Compile := "gbf-raidfinder",
     herokuSkipSubProjects in Compile := false,
     herokuProcessTypes in Compile := Map(
-      "web" -> s"target/universal/stage/bin/${name.value} -Dhttp.port=$$PORT -Dapplication.mode=prod"
+      "web" -> Seq(
+        s"target/universal/stage/bin/${name.value}",
+        "-Dhttp.port=$PORT",
+        "-Dapplication.cache.redisUrl=$REDIS_URL",
+        "-Dapplication.mode=prod"
+      ).mkString(" ")
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,11 +32,14 @@ lazy val server = (project in file("server"))
   .settings(commonSettings: _*)
   .settings(
     name := "gbf-raidfinder-server",
+    resolvers += Resolver.jcenterRepo, // for ficus
     libraryDependencies ++= Seq(
+      "com.iheart" %% "ficus" % "1.2.6",
       "com.trueaccord.scalapb" %% "scalapb-json4s" % Versions.ScalaPB_json4s,
       "com.typesafe.play" %% "filters-helpers" % Versions.Play,
       "com.typesafe.play" %% "play-netty-server" % Versions.Play,
-      "com.typesafe.play" %% "play-logback" % Versions.Play
+      "com.typesafe.play" %% "play-logback" % Versions.Play,
+      "redis.clients" % "jedis" % "2.8.1"
     )
   )
   .dependsOn(stream, protocolJVM)

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -10,5 +10,13 @@ application {
   # param, no-op messages will be sent to the client periodically, using
   # this interval.
   websocket.keepAliveInterval = 30s
+
+  cache {
+    # Optional Redis URL, formatted `redis://user:pass@host:1234`
+    # redisUrl =
+
+    flushInterval = 30s
+    bossesKey = bosses
+  }
 }
 

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -12,11 +12,14 @@ application {
   websocket.keepAliveInterval = 30s
 
   cache {
-    # Optional Redis URL, formatted `redis://user:pass@host:1234`
+    # Optional Redis URL, formatted "redis://user:pass@host:1234"
     # redisUrl =
 
-    flushInterval = 30s
-    bossesKey = bosses
+    bosses {
+      cacheKey = bosses
+      ttl = 6h
+      flushInterval = 30s
+    }
   }
 }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -20,7 +20,7 @@ import walfie.gbf.raidfinder.RaidFinder
 
 object Application {
   def main(args: Array[String]): Unit = {
-    val raidFinder = RaidFinder.withBacklog()
+    val raidFinder = RaidFinder.withBacklog(initialBosses = Seq.empty)
 
     val config = ConfigFactory.load()
     val port = config.getInt("http.port")

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -61,17 +61,7 @@ object Application {
       protobufStorage.close()
     }
 
-    if (mode == Mode.Dev) {
-      Logger.info("Press ENTER to stop the application.")
-      scala.io.StdIn.readLine()
-      Logger.info("Stopping application...")
-      shutdown()
-      Logger.info("Application stopped.")
-    }
-
-    Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = shutdown()
-    })
+    handleShutdown(mode, shutdown)
   }
 
   def getMode(s: String): Mode.Mode = s match {
@@ -92,6 +82,20 @@ object Application {
     storage
       .get[RaidBossesResponse](key)
       .fold(Seq.empty[domain.RaidBoss])(_.raidBosses.map(_.toDomain))
+  }
+
+  def handleShutdown(mode: Mode.Mode, shutdown: () => Unit) = {
+    if (mode == Mode.Dev) {
+      Logger.info("Press ENTER to stop the application.")
+      scala.io.StdIn.readLine()
+      Logger.info("Stopping application...")
+      shutdown()
+      Logger.info("Application stopped.")
+    }
+
+    Runtime.getRuntime.addShutdownHook(new Thread() {
+      override def run(): Unit = shutdown()
+    })
   }
 }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -24,7 +24,7 @@ object Application {
 
     // Get initial bosses from cache
     val protobufStorage = {
-      val url = appConfig.as[Option[String]]("cache.redisUrl")
+      val url = appConfig.as[Option[String]]("cache.redisUrl").filter(_.nonEmpty)
       getProtobufStorage(url)
     }
     val bossCacheKey = appConfig.as[String]("cache.bossesKey")
@@ -48,6 +48,7 @@ object Application {
     val components = new Components(raidFinder, port, mode, keepAliveInterval)
     val server = components.server
 
+    // Shutdown handling
     val shutdown = () => {
       server.stop()
       protobufStorage.close()

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -1,48 +1,68 @@
 package walfie.gbf.raidfinder.server
 
 import akka.actor._
-import akka.stream.ActorMaterializer
-import com.typesafe.config.ConfigFactory
-import java.util.concurrent.TimeUnit
-import monix.execution.Scheduler.Implicits.global
-import play.api.http.DefaultHttpErrorHandler
+import com.typesafe.config.{Config, ConfigFactory}
+import java.net.URI
+import net.ceedubs.ficus.Ficus._
 import play.api.mvc._
-import play.api.routing.Router
-import play.api.routing.sird._
-import play.api.{BuiltInComponents, Logger, Mode}
+import play.api.{Logger, Mode}
 import play.core.server._
-import play.core.server.NettyServerComponents
 import scala.concurrent.duration._
-import scala.concurrent.Future
-import scala.util.control.NonFatal
-import walfie.gbf.raidfinder
+import walfie.gbf.raidfinder.domain
+import walfie.gbf.raidfinder.protocol._
 import walfie.gbf.raidfinder.RaidFinder
+import walfie.gbf.raidfinder.server.persistence._
+import walfie.gbf.raidfinder.server.syntax.ProtocolConverters._
+import walfie.gbf.raidfinder.util.BlockingIO
 
 object Application {
   def main(args: Array[String]): Unit = {
-    val raidFinder = RaidFinder.withBacklog(initialBosses = Seq.empty)
+    implicit val scheduler = monix.execution.Scheduler.Implicits.global
 
     val config = ConfigFactory.load()
-    val port = config.getInt("http.port")
+    val appConfig = config.getConfig("application")
 
-    val mode = getMode(config.getString("application.mode"))
-    val keepAliveInterval = config.getDuration(
-      "application.websocket.keepAliveInterval",
-      TimeUnit.MILLISECONDS
-    ).milliseconds
+    // Get initial bosses from cache
+    val protobufStorage = {
+      val url = appConfig.as[Option[String]]("cache.redisUrl")
+      getProtobufStorage(url)
+    }
+    val bossCacheKey = appConfig.as[String]("cache.bossesKey")
+    val bossFlushInterval = appConfig.as[FiniteDuration]("cache.flushInterval")
+    val cachedBosses = getCachedBosses(protobufStorage, bossCacheKey)
+
+    // Start RaidFinder
+    val raidFinder = RaidFinder.withBacklog(initialBosses = cachedBosses)
+
+    // Periodically flush bosses to cache
+    scheduler.scheduleWithFixedDelay(bossFlushInterval, bossFlushInterval) {
+      val bosses = raidFinder.getKnownBosses().values.map(_.toProtocol)
+      val bossesResponse = RaidBossesResponse(raidBosses = bosses.toSeq)
+      BlockingIO.future(protobufStorage.set(bossCacheKey, bossesResponse))
+    }
+
+    // Start server
+    val port = config.as[Int]("http.port")
+    val mode = getMode(appConfig.as[String]("mode"))
+    val keepAliveInterval = appConfig.as[FiniteDuration]("websocket.keepAliveInterval")
     val components = new Components(raidFinder, port, mode, keepAliveInterval)
     val server = components.server
+
+    val shutdown = () => {
+      server.stop()
+      protobufStorage.close()
+    }
 
     if (mode == Mode.Dev) {
       Logger.info("Press ENTER to stop the application.")
       scala.io.StdIn.readLine()
       Logger.info("Stopping application...")
-      server.stop()
+      shutdown()
       Logger.info("Application stopped.")
     }
 
     Runtime.getRuntime.addShutdownHook(new Thread() {
-      override def run(): Unit = server.stop()
+      override def run(): Unit = shutdown()
     })
   }
 
@@ -52,6 +72,18 @@ object Application {
     case unknown => throw new IllegalArgumentException(
       s"""Unknown application.mode "$unknown" (Must be one of: dev, prod)"""
     )
+  }
+
+  def getProtobufStorage(redisUrl: Option[String]): ProtobufStorage = {
+    redisUrl.fold[ProtobufStorage](NoOpProtobufStorage) { url =>
+      ProtobufStorage.redis(new URI(url))
+    }
+  }
+
+  def getCachedBosses(storage: ProtobufStorage, key: String): Seq[domain.RaidBoss] = {
+    storage
+      .get[RaidBossesResponse](key)
+      .fold(Seq.empty[domain.RaidBoss])(_.raidBosses.map(_.toDomain))
   }
 }
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/persistence/ProtobufStorage.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/persistence/ProtobufStorage.scala
@@ -1,0 +1,50 @@
+package walfie.gbf.raidfinder.server.persistence
+
+import com.trueaccord.scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import java.net.URI
+import redis.clients.jedis.{BinaryJedis, Jedis}
+
+trait ProtobufStorage {
+  type MessageT[T] = GeneratedMessage with Message[T]
+
+  def set[T <: MessageT[T]](key: String, value: T): Unit
+  def get[T <: MessageT[T]](
+    key: String
+  )(implicit companion: GeneratedMessageCompanion[T]): Option[T]
+
+  def close(): Unit
+}
+
+object ProtobufStorage {
+  def redis(uri: URI): RedisProtobufStorage = {
+    new RedisProtobufStorage(new BinaryJedis(uri))
+  }
+}
+
+// TODO: Write integration test
+class RedisProtobufStorage(redis: BinaryJedis) extends ProtobufStorage {
+  def set[T <: MessageT[T]](key: String, value: T): Unit = {
+    redis.set(key.getBytes, value.toByteArray)
+  }
+
+  def get[T <: MessageT[T]](
+    key: String
+  )(implicit companion: GeneratedMessageCompanion[T]): Option[T] = {
+    Option(redis.get(key.getBytes)).flatMap { bytes =>
+      companion.validate(bytes).toOption
+    }
+  }
+
+  def close(): Unit = redis.close()
+}
+
+object NoOpProtobufStorage extends ProtobufStorage {
+  def set[T <: MessageT[T]](key: String, value: T): Unit = ()
+
+  def get[T <: MessageT[T]](
+    key: String
+  )(implicit companion: GeneratedMessageCompanion[T]): Option[T] = None
+
+  def close(): Unit = ()
+}
+

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/persistence/ProtobufStorage.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/persistence/ProtobufStorage.scala
@@ -5,10 +5,10 @@ import java.net.URI
 import redis.clients.jedis.{BinaryJedis, Jedis}
 
 trait ProtobufStorage {
-  type MessageT[T] = GeneratedMessage with Message[T]
+  type CacheItem[T] = GeneratedMessage with Message[T]
 
-  def set[T <: MessageT[T]](key: String, value: T): Unit
-  def get[T <: MessageT[T]](
+  def set[T <: CacheItem[T]](key: String, value: T): Unit
+  def get[T <: CacheItem[T]](
     key: String
   )(implicit companion: GeneratedMessageCompanion[T]): Option[T]
 
@@ -23,11 +23,11 @@ object ProtobufStorage {
 
 // TODO: Write integration test
 class RedisProtobufStorage(redis: BinaryJedis) extends ProtobufStorage {
-  def set[T <: MessageT[T]](key: String, value: T): Unit = {
+  def set[T <: CacheItem[T]](key: String, value: T): Unit = {
     redis.set(key.getBytes, value.toByteArray)
   }
 
-  def get[T <: MessageT[T]](
+  def get[T <: CacheItem[T]](
     key: String
   )(implicit companion: GeneratedMessageCompanion[T]): Option[T] = {
     Option(redis.get(key.getBytes)).flatMap { bytes =>
@@ -39,9 +39,9 @@ class RedisProtobufStorage(redis: BinaryJedis) extends ProtobufStorage {
 }
 
 object NoOpProtobufStorage extends ProtobufStorage {
-  def set[T <: MessageT[T]](key: String, value: T): Unit = ()
+  def set[T <: CacheItem[T]](key: String, value: T): Unit = ()
 
-  def get[T <: MessageT[T]](
+  def get[T <: CacheItem[T]](
     key: String
   )(implicit companion: GeneratedMessageCompanion[T]): Option[T] = None
 

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/syntax/ProtocolConverters.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/syntax/ProtocolConverters.scala
@@ -1,0 +1,20 @@
+package walfie.gbf.raidfinder.server.syntax
+
+import walfie.gbf.raidfinder.domain
+import walfie.gbf.raidfinder.protocol
+
+/** Convenient converters between domain objects and protobuf objects */
+object ProtocolConverters {
+  implicit class RaidBossDomainOps(val rb: domain.RaidBoss) extends AnyVal {
+    def toProtocol(): protocol.RaidBoss = protocol.RaidBoss(
+      name = rb.name, level = rb.level, image = rb.image, lastSeen = rb.lastSeen
+    )
+  }
+
+  implicit class RaidBossProtocolOps(val rb: protocol.RaidBoss) extends AnyVal {
+    def toDomain(): domain.RaidBoss = domain.RaidBoss(
+      name = rb.name, level = rb.level, image = rb.image, lastSeen = rb.lastSeen
+    )
+  }
+}
+

--- a/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
@@ -1,6 +1,7 @@
 package walfie.gbf.raidfinder
 
 import akka.agent.Agent
+import java.util.Date
 import monix.execution.{Ack, Cancelable, Scheduler}
 import monix.reactive._
 import scala.concurrent.{ExecutionContext, Future}
@@ -8,6 +9,7 @@ import walfie.gbf.raidfinder.domain._
 
 trait KnownBossesMap {
   def get(): Map[BossName, RaidBoss]
+  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]]
 }
 
 object KnownBossesObserver {
@@ -41,5 +43,10 @@ class KnownBossesObserver(
   }
 
   def get(): Map[BossName, RaidBoss] = agent.get()
+  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]] = {
+    agent.alter(_.filter {
+      case (name, boss) => boss.lastSeen.after(minDate)
+    })
+  }
 }
 

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -1,9 +1,11 @@
 package walfie.gbf.raidfinder
 
+import java.util.Date
 import monix.eval.Task
 import monix.execution.{Cancelable, Scheduler}
 import monix.reactive._
 import scala.concurrent.duration._
+import scala.concurrent.Future
 import twitter4j._
 import walfie.gbf.raidfinder.domain._
 
@@ -11,6 +13,7 @@ trait RaidFinder {
   def getRaidTweets(bossName: BossName): Observable[RaidTweet]
   def newBossObservable: Observable[RaidBoss]
   def getKnownBosses(): Map[BossName, RaidBoss]
+  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]]
   def shutdown(): Unit
 }
 
@@ -107,5 +110,7 @@ class DefaultRaidFinder(
     knownBosses.get()
   def getRaidTweets(bossName: BossName): Observable[RaidTweet] =
     partitioner.getObservable(bossName)
+  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]] =
+    knownBosses.purgeOldBosses(minDate)
 }
 

--- a/stream/src/test/scala/walfie/gbf/raidfinder/KnownBossesObserverSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/KnownBossesObserverSpec.scala
@@ -14,8 +14,12 @@ import scala.util.Random
 import walfie.gbf.raidfinder.domain._
 
 class KnownBossesObserverSpec extends KnownBossesObserverSpecHelpers {
-  "Start empty" in new ObserverFixture {
-    observer.get shouldBe Map.empty[BossName, RaidInfo]
+  "Start with initial value" in new ObserverFixture {
+    val boss1 = mockRaidInfo("A").boss
+    val boss2 = mockRaidInfo("B").boss
+    override val initialBosses = Seq(boss1, boss2)
+
+    observer.get shouldBe Map("A" -> boss1, "B" -> boss2)
     cancelable.cancel()
   }
 
@@ -25,12 +29,14 @@ class KnownBossesObserverSpec extends KnownBossesObserverSpecHelpers {
 
     bosses1.foreach(raidInfos.onNext)
     bosses2.foreach(raidInfos.onNext)
-    scheduler.tick()
 
-    observer.get shouldBe Map(
-      "A" -> bosses1.last,
-      "B" -> bosses2.last
-    ).mapValues(_.boss)
+    eventually {
+      scheduler.tick()
+      observer.get shouldBe Map(
+        "A" -> bosses1.last.boss,
+        "B" -> bosses2.last.boss
+      )
+    }
     cancelable.cancel()
   }
 }
@@ -38,8 +44,10 @@ class KnownBossesObserverSpec extends KnownBossesObserverSpecHelpers {
 trait KnownBossesObserverSpecHelpers extends FreeSpec with MockitoSugar with Eventually {
   trait ObserverFixture {
     implicit val scheduler = TestScheduler()
+    val initialBosses: Seq[RaidBoss] = Seq.empty
     val raidInfos = ConcurrentSubject.replay[RaidInfo]
-    val (observer, cancelable) = KnownBossesObserver.fromRaidInfoObservable(raidInfos)
+    lazy val (observer, cancelable) = KnownBossesObserver
+      .fromRaidInfoObservable(raidInfos, initialBosses)
   }
 
   def mockRaidInfo(bossName: String): RaidInfo = {
@@ -47,6 +55,7 @@ trait KnownBossesObserverSpecHelpers extends FreeSpec with MockitoSugar with Eve
     when(tweet.bossName) thenReturn bossName
     when(tweet.createdAt) thenReturn (new Date(Random.nextLong.abs * 1000))
     val boss = mock[RaidBoss]
+    when(boss.name) thenReturn bossName
     RaidInfo(tweet, boss)
   }
 }


### PR DESCRIPTION
This allows the option of periodically storing known bosses in Redis.
- Redis is optional -- if URL is unspecified in the config, it will fall
  back to a no-op cache.
- Cache item is stored as a serialized protobuf message
- Bosses fetched from Redis on startup
- Periodically purge old bosses

Fixes #37
