### PR TITLE
Don't remove high level bosses

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -19,6 +19,7 @@ application {
       cacheKey = bosses
       ttl = 6h
       flushInterval = 30s
+      levelThreshold = 100 # Bosses higher than this level (inclusive) are not removed
     }
   }
 }

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -41,7 +41,10 @@ object Application {
       // Purge old bosses and then update the cache
       val purgeMinDate = new Date(System.currentTimeMillis() - bossStorageConfig.ttl.toMillis)
       for {
-        bosses <- raidFinder.purgeOldBosses(purgeMinDate)
+        bosses <- raidFinder.purgeOldBosses(
+          minDate = purgeMinDate,
+          levelThreshold = bossStorageConfig.levelThreshold
+        )
         cacheObj = RaidBossesResponse(raidBosses = bosses.values.map(_.toProtocol).toSeq)
         _ <- BlockingIO.future(protobufStorage.set(bossStorageConfig.cacheKey, cacheObj))
       } yield ()
@@ -100,8 +103,9 @@ object Application {
 }
 
 case class BossStorageConfig(
-  cacheKey:      String,
-  ttl:           FiniteDuration,
-  flushInterval: FiniteDuration
+  cacheKey:       String,
+  ttl:            FiniteDuration,
+  flushInterval:  FiniteDuration,
+  levelThreshold: Int
 )
 

--- a/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
@@ -9,7 +9,12 @@ import walfie.gbf.raidfinder.domain._
 
 trait KnownBossesMap {
   def get(): Map[BossName, RaidBoss]
-  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]]
+
+  /**
+    * @param minDate Remove bosses that haven't been seen since this date
+    * @param levelThreshold Bosses higher than this level (inclusive) will not be removed
+    */
+  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]]
 }
 
 object KnownBossesObserver {
@@ -43,9 +48,12 @@ class KnownBossesObserver(
   }
 
   def get(): Map[BossName, RaidBoss] = agent.get()
-  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]] = {
+  def purgeOldBosses(
+    minDate:        Date,
+    levelThreshold: Int
+  ): Future[Map[BossName, RaidBoss]] = {
     agent.alter(_.filter {
-      case (name, boss) => boss.lastSeen.after(minDate)
+      case (name, boss) => boss.lastSeen.after(minDate) || boss.level >= levelThreshold
     })
   }
 }

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -13,7 +13,7 @@ trait RaidFinder {
   def getRaidTweets(bossName: BossName): Observable[RaidTweet]
   def newBossObservable: Observable[RaidBoss]
   def getKnownBosses(): Map[BossName, RaidBoss]
-  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]]
+  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]]
   def shutdown(): Unit
 }
 
@@ -110,7 +110,7 @@ class DefaultRaidFinder(
     knownBosses.get()
   def getRaidTweets(bossName: BossName): Observable[RaidTweet] =
     partitioner.getObservable(bossName)
-  def purgeOldBosses(minDate: Date): Future[Map[BossName, RaidBoss]] =
-    knownBosses.purgeOldBosses(minDate)
+  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]] =
+    knownBosses.purgeOldBosses(minDate, levelThreshold)
 }
 


### PR DESCRIPTION
Bosses higher than a certain level won't be removed on the periodic
boss cleanup. This is because HL boss tweets happen infrequently.

Closes #46
