### PR TITLE
Fix background color of boss selector

### DIFF
--- a/client/src/main/resources/public/css/base.css
+++ b/client/src/main/resources/public/css/base.css
@@ -253,7 +253,7 @@ html, body, .gbfrf-container {
 
 .gbfrf-theme--light
 ::-webkit-scrollbar-thumb {
-  background-color: #e1e8ed;
+  background-color: #cbd1d6;
 }
 
 .gbfrf-theme--light

--- a/client/src/main/resources/public/css/dark.css
+++ b/client/src/main/resources/public/css/dark.css
@@ -9,6 +9,12 @@
 }
 
 .gbfrf-theme--dark
+.gbfrf-follow__boss-box {
+  color: white;
+  background-color: #222426;
+}
+
+.gbfrf-theme--dark
 .gbfrf-tweet {
   color: white;
 }


### PR DESCRIPTION
There was no dark style, so it was showing a white background.
Also increase the contrast on light theme scroll bars.
