### PR TITLE
Add desktop notifications

### DIFF
--- a/client/src/main/resources/public/css/base.css
+++ b/client/src/main/resources/public/css/base.css
@@ -61,12 +61,25 @@ html, body, .gbfrf-container {
 }
 
 .gbfrf-column__header-row {
+  position: relative;
   padding: 20px !important;
   background-position: 0 20%;
   background-size: 100% !important;
 }
 
 .gbfrf-column__header-row-icon {
+  vertical-align: middle;
+}
+
+.gbfrf-column__notification-banner {
+  text-align: center;
+  background-color: #eaeaea;
+  color: #292f33;
+  line-height: 30px;
+}
+
+.gbfrf-column__notification-banner-icon {
+  font-size: 1.25em;
   vertical-align: middle;
 }
 

--- a/client/src/main/resources/public/css/dark.css
+++ b/client/src/main/resources/public/css/dark.css
@@ -3,6 +3,13 @@
   background: #222426;
 }
 
+
+.gbfrf-theme--dark
+.gbfrf-column__notification-banner {
+  background-color: #3c444a;
+  color: #fff;
+}
+
 .gbfrf-theme--dark
 .gbfrf-dialog {
   background: #222426;
@@ -10,13 +17,13 @@
 
 .gbfrf-theme--dark
 .gbfrf-follow__boss-box {
-  color: white;
+  color: #fff;
   background-color: #222426;
 }
 
 .gbfrf-theme--dark
 .gbfrf-tweet {
-  color: white;
+  color: #fff;
 }
 
 .gbfrf-theme--dark
@@ -26,12 +33,12 @@
 
 .gbfrf-theme--dark
 .gbfrf-settings__item {
-  color: white;
+  color: #fff;
 }
 
 .gbfrf-theme--dark
 .gbfrf-dialog__button {
-  color: white;
+  color: #fff;
 }
 
 .gbfrf-theme--dark

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -116,17 +116,15 @@ class WebSocketRaidFinderClient(
   }
 
   private def setSubscription(bossName: BossName, changeState: Boolean => Boolean): Unit = {
-    allBossesMap.get(bossName).foreach { boss =>
-      boss.isSubscribed := changeState(boss.isSubscribed.get)
+    HtmlHelpers.requestNotificationPermission { () =>
+      allBossesMap.get(bossName).foreach { boss =>
+        boss.isSubscribed := changeState(boss.isSubscribed.get)
+      }
+      updateLocalStorageSubscribed()
     }
-    updateLocalStorageSubscribed()
   }
 
-  def subscribe(bossName: BossName): Unit = {
-    HtmlHelpers.requestNotificationPermission(
-      setSubscription(bossName, _ => true)
-    )
-  }
+  def subscribe(bossName: BossName): Unit = setSubscription(bossName, _ => true)
   def unsubscribe(bossName: BossName): Unit = setSubscription(bossName, _ => false)
   def toggleSubscribe(bossName: BossName): Unit = setSubscription(bossName, !_)
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/util/HtmlHelpers.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/util/HtmlHelpers.scala
@@ -1,8 +1,10 @@
 package walfie.gbf.raidfinder.client.util
 
+import org.scalajs.dom.experimental.{Notification, NotificationOptions}
 import org.scalajs.dom.raw._
 import org.scalajs.dom.{console, document}
 import scala.annotation.tailrec
+import scala.scalajs.js
 import scala.util.{Success, Failure, Try}
 
 object HtmlHelpers {
@@ -14,6 +16,32 @@ object HtmlHelpers {
     else Option(element.parentNode) match {
       case Some(parentElement: Element) => findParent(parentElement, predicate)
       case _ => None
+    }
+  }
+
+  def requestNotificationPermission(onSuccess: => Unit = ()): Unit = {
+    if (Notification.permission == "granted")
+      onSuccess
+    else Notification.requestPermission { result: String =>
+      if (result == "granted") onSuccess
+    }
+  }
+
+  def desktopNotification(
+    title:        String,
+    body:         js.UndefOr[String],
+    icon:         js.UndefOr[String],
+    tag:          js.UndefOr[String],
+    onClick:      Event => Unit,
+    closeOnClick: Boolean
+  ): Unit = {
+    requestNotificationPermission {
+      val options = NotificationOptions(body = body, icon = icon, tag = tag)
+      val notification = new Notification(title, options)
+      notification.asInstanceOf[js.Dynamic].onclick = { e: Event =>
+        onClick(e)
+        if (closeOnClick) notification.close()
+      }
     }
   }
 

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/util/HtmlHelpers.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/util/HtmlHelpers.scala
@@ -19,11 +19,11 @@ object HtmlHelpers {
     }
   }
 
-  def requestNotificationPermission(onSuccess: => Unit = ()): Unit = {
+  def requestNotificationPermission(onSuccess: () => Unit): Unit = {
     if (Notification.permission == "granted")
-      onSuccess
+      onSuccess()
     else Notification.requestPermission { result: String =>
-      if (result == "granted") onSuccess
+      if (result == "granted") onSuccess()
     }
   }
 
@@ -35,7 +35,7 @@ object HtmlHelpers {
     onClick:      Event => Unit,
     closeOnClick: Boolean
   ): Unit = {
-    requestNotificationPermission {
+    requestNotificationPermission { () =>
       val options = NotificationOptions(body = body, icon = icon, tag = tag)
       val notification = new Notification(title, options)
       notification.asInstanceOf[js.Dynamic].onclick = { e: Event =>

--- a/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/views/MainContent.scala
@@ -33,8 +33,7 @@ object MainContent {
           {
             client.state.followedBosses.map { column =>
               RaidTweets.raidTweetColumn(
-                column.raidBoss, column.raidTweets, currentTime,
-                client, notification, viewState
+                column, currentTime, client, notification, viewState
               ).bind
             }
           }


### PR DESCRIPTION
This adds a "subscribe" button in the boss menu that will enable
desktop notifications for whenever a tweet is made about that boss.

The desktop notification can be clicked to copy the raid ID to the
user's clipboard.

![1473828576](https://cloud.githubusercontent.com/assets/11370525/18500485/d81a055e-7a15-11e6-8b36-e8290f715f82.png)

Closes #52
