### PR TITLE
Handle newlines in raid text message

### DIFF
--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -31,7 +31,7 @@ object Application {
     val cachedBosses = getCachedBosses(protobufStorage, bossStorageConfig.cacheKey)
 
     // Start RaidFinder
-    val raidFinder = RaidFinder.withBacklog(initialBosses = cachedBosses)
+    val raidFinder = RaidFinder.withBackfill(initialBosses = cachedBosses)
 
     // Periodically flush bosses to cache
     val bossFlushCancelable = scheduler.scheduleWithFixedDelay(

--- a/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
@@ -6,8 +6,8 @@ import scala.util.Try
 
 object StatusParser {
   /** Regexes to match raid request tweets */
-  val RaidRegexJapanese = "(.*)参加者募集！参戦ID：([0-9A-F]+)\n(.+)\n?.*".r
-  val RaidRegexEnglish = "(.*)I need backup!Battle ID: ([0-9A-F]+)\n(.+)\n?.*".r
+  val RaidRegexJapanese = "((?s).*)参加者募集！参戦ID：([0-9A-F]+)\n(.+)\n?.*".r
+  val RaidRegexEnglish = "((?s).*)I need backup!Battle ID: ([0-9A-F]+)\n(.+)\n?.*".r
 
   /**
     * Regex to get boss level from full name

--- a/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -10,7 +10,7 @@ import twitter4j._
 import walfie.gbf.raidfinder.domain._
 
 class StatusParserSpec extends StatusParserSpecHelpers {
-  "parse a valid status in Japanese" in {
+  "parse a valid status in Japanese" - {
     val expectedRaidTweet = RaidTweet(
       tweetId = 12345L,
       screenName = "walfieee",
@@ -28,12 +28,26 @@ class StatusParserSpec extends StatusParserSpecHelpers {
       lastSeen = now
     )
 
-    StatusParser.parse(mockStatus()) shouldBe Some {
-      RaidInfo(expectedRaidTweet, expectedRaidBoss)
+    "with extra text" in {
+      StatusParser.parse(mockStatus()) shouldBe Some {
+        RaidInfo(expectedRaidTweet, expectedRaidBoss)
+      }
     }
+
+    "without extra text" in {
+      val text = """
+        |参加者募集！参戦ID：ABCD1234
+        |Lv60 オオゾラッコ
+        |http://example.com/raid-image.png""".stripMargin.trim
+
+      StatusParser.parse(mockStatus(text = text)) shouldBe Some {
+        RaidInfo(expectedRaidTweet.copy(text = ""), expectedRaidBoss)
+      }
+    }
+
   }
 
-  "parse a valid status in English" in {
+  "parse a valid status in English" - {
     val expectedRaidTweet = RaidTweet(
       tweetId = 12345L,
       screenName = "walfieee",
@@ -51,13 +65,26 @@ class StatusParserSpec extends StatusParserSpecHelpers {
       lastSeen = now
     )
 
-    val text = """
-      |INSERT CUSTOM MESSAGE HERE I need backup!Battle ID: ABCD1234
-      |Lvl 60 Ozorotter""".stripMargin.trim
-    val status = mockStatus(text = text)
+    "with extra text" in {
+      val text = """
+        |INSERT CUSTOM MESSAGE HERE I need backup!Battle ID: ABCD1234
+        |Lvl 60 Ozorotter""".stripMargin.trim
+      val status = mockStatus(text = text)
 
-    StatusParser.parse(status) shouldBe Some {
-      RaidInfo(expectedRaidTweet, expectedRaidBoss)
+      StatusParser.parse(status) shouldBe Some {
+        RaidInfo(expectedRaidTweet, expectedRaidBoss)
+      }
+    }
+
+    "without extra text" in {
+      val text = """
+        |I need backup!Battle ID: ABCD1234
+        |Lvl 60 Ozorotter""".stripMargin.trim
+      val status = mockStatus(text = text)
+
+      StatusParser.parse(status) shouldBe Some {
+        RaidInfo(expectedRaidTweet.copy(text = ""), expectedRaidBoss)
+      }
     }
   }
 

--- a/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -34,11 +34,26 @@ class StatusParserSpec extends StatusParserSpecHelpers {
       }
     }
 
+    "with newlines in extra text" in {
+      val text = """
+        |Hey
+        |Newlines
+        |Are
+        |Cool
+        |参加者募集！参戦ID：ABCD1234
+        |Lv60 オオゾラッコ
+        |http://example.com/image-that-is-ignored.png""".stripMargin.trim
+
+      StatusParser.parse(mockStatus(text = text)) shouldBe Some {
+        RaidInfo(expectedRaidTweet.copy(text = "Hey\nNewlines\nAre\nCool"), expectedRaidBoss)
+      }
+    }
+
     "without extra text" in {
       val text = """
         |参加者募集！参戦ID：ABCD1234
         |Lv60 オオゾラッコ
-        |http://example.com/raid-image.png""".stripMargin.trim
+        |http://example.com/image-that-is-ignored.png""".stripMargin.trim
 
       StatusParser.parse(mockStatus(text = text)) shouldBe Some {
         RaidInfo(expectedRaidTweet.copy(text = ""), expectedRaidBoss)
@@ -76,10 +91,27 @@ class StatusParserSpec extends StatusParserSpecHelpers {
       }
     }
 
+    "with newlines in extra text" in {
+      val text = """
+        |Hey
+        |Newlines
+        |Are
+        |Cool
+        |I need backup!Battle ID: ABCD1234
+        |Lvl 60 Ozorotter
+        |http://example.com/image-that-is-ignored.png""".stripMargin.trim
+      val status = mockStatus(text = text)
+
+      StatusParser.parse(status) shouldBe Some {
+        RaidInfo(expectedRaidTweet.copy(text = "Hey\nNewlines\nAre\nCool"), expectedRaidBoss)
+      }
+    }
+
     "without extra text" in {
       val text = """
         |I need backup!Battle ID: ABCD1234
-        |Lvl 60 Ozorotter""".stripMargin.trim
+        |Lvl 60 Ozorotter
+        |http://example.com/image-that-is-ignored.png""".stripMargin.trim
       val status = mockStatus(text = text)
 
       StatusParser.parse(status) shouldBe Some {


### PR DESCRIPTION
The previous parser wasn't considering newlines in the raid text message 
(The part before "I need backup!" or "参加者募集！")

Also rename backlog to backfill because it's a more accurate name.
