### PR TITLE
Fix English tweets being excluded from stream

### DIFF
--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -48,7 +48,7 @@ class WebsocketRaidsHandler(
 
     case r: FollowRequest =>
       val cancelables = r.bossNames
-        .filterNot(followed.keys.toSeq.contains)
+        .filterNot(followed.keys.toSet.contains)
         .map { bossName =>
           bossName -> raidFinder.getRaidTweets(bossName).foreach { r: RaidTweet =>
             // TODO: Add utils for converting domain objects to protobuf messages

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -74,6 +74,7 @@ class DefaultRaidFinder(
   /** Override this to perform additional cleanup on shutdown */
   protected def onShutdown(): Unit = ()
 
+  // TODO: Parsing happens twice somewhere -- should figure out where
   private val raidInfos = statusesObservable
     .collect(Function.unlift(StatusParser.parse))
     .publish

--- a/stream/src/main/scala/walfie/gbf/raidfinder/TwitterStreamer.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/TwitterStreamer.scala
@@ -11,10 +11,10 @@ trait TwitterStreamer {
 }
 
 object TwitterStreamer {
-  // For English tweets, we can just search "I need backup!"
+  // For English tweets, we can just search "I need backup!Battle ID:"
   // For Japanese tweets we can't just use "参加者募集！" since words must be
   // space-separated, and the only space-separated thing is the boss level.
-  val DefaultFilterTerms = (15 to 150 by 5).map("Lv" + _) :+ "I need backup!"
+  val DefaultFilterTerms = (15 to 150 by 5).map("Lv" + _) :+ "I need backup!Battle ID:"
 
   def apply(
     twitterStream: twitter4j.TwitterStream = TwitterStreamFactory.getSingleton,


### PR DESCRIPTION
Previously, the only English tweets that showed up in columns were ones
that had Japanese text in them (typically the name of the boss).

For some reason, filtering the stream by "I need backup!" only returns
tweets if there is text before "I need backup!" (not sure if the text
needs to be Japanese or if it's any text). Twitter's streaming API is
weird when dealing with CJK text and filtering by full words.

This changes it to filter by "I need backup!Battle ID:" instead.

Fixes #59
