### PR TITLE
Disable notifications for startup backfill tweets

### DIFF
--- a/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/Application.scala
@@ -19,7 +19,7 @@ object Application {
 
     val websocket = new BinaryProtobufWebSocketClient(url, maxReconnectInterval)
 
-    val client = new WebSocketRaidFinderClient(
+    val client: RaidFinderClient = new WebSocketRaidFinderClient(
       websocket, dom.window.localStorage, SystemClock
     )
 


### PR DESCRIPTION
Adds an `isStartingUp` state to the client which suppresses
notifications until 1 second after the initial websocket connection is
established.

Closes #71
