### PR TITLE
Revert "Set `-Dfile.encoding=UTF-8` in Heroku settings"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,6 @@ lazy val root = (project in file("."))
     herokuProcessTypes in Compile := Map(
       "web" -> Seq(
         s"target/universal/stage/bin/${name.value}",
-        "-Dfile.encoding=UTF-8",
         "-Dhttp.port=$PORT",
         "-Dapplication.cache.redisUrl=$REDIS_URL",
         "-Dapplication.mode=prod"


### PR DESCRIPTION
Reverts walfie/gbf-raidfinder#81

Turns out it's not actually needed, since it's a Chrome bug from 2014:
https://bugs.chromium.org/p/chromium/issues/detail?id=438464
