### PR TITLE
Limit number of search API calls on startup

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -25,7 +25,7 @@ application {
   bosses {
     cacheKey = bosses
     ttl = 12h
-    flushInterval = 30s
+    flushInterval = 60s
     levelThreshold = 100 # Bosses higher than this level (inclusive) are not removed from cache
   }
 

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -51,8 +51,8 @@ object RaidFinder {
     val backfillTask: Task[Seq[Status]] =
       TwitterSearcher(twitter, TwitterSearcher.ReverseChronological)
         .observable(DefaultSearchTerm, None, MaxCount)
+        .take(backfillSize / MaxCount)
         .flatMap(Observable.fromIterable)
-        .take(backfillSize)
         .toListL
         .map(_.sortBy(_.getCreatedAt)) // earliest first
 


### PR DESCRIPTION
Previous code would keep searching until it gets 400 tweets, regardless
of how many API calls it takes. This limits it to 4 calls. If we get
less than 400 tweets, it's fine.

Also decrease the cache flush frequency.
