### PR TITLE
Switch from Heroku Redis to Redis Cloud

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ lazy val root = (project in file("."))
       "web" -> Seq(
         s"target/universal/stage/bin/${name.value}",
         "-Dhttp.port=$PORT",
-        "-Dapplication.cache.redisUrl=$REDIS_URL",
+        "-Dapplication.cache.redisUrl=$REDISCLOUD_URL",
         "-Dapplication.mode=prod"
       ).mkString(" ")
     )


### PR DESCRIPTION
Heroku Redis has weekly maintenance windows which causes the cache to
be reset (causing the app to "forget" about existing bosses on startup).
Hopefully Redis Cloud is better about this.

Fixes #85 (maybe)
