### PR TITLE
Fix missing backfill tweets

### DIFF
--- a/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
+++ b/client/src/main/scala/walfie/gbf/raidfinder/client/RaidFinderClient.scala
@@ -24,7 +24,7 @@ trait RaidFinderClient {
   def updateAllBosses(): Unit
   def resetBossList(): Unit
 
-  def follow(bossName: BossName): Unit
+  def follow(bossName: BossName, sendMessage: Boolean = true): Unit
   def unfollow(bossName: BossName): Unit
   def toggleFollow(bossName: BossName): Unit
 
@@ -51,7 +51,6 @@ class WebSocketRaidFinderClient(
 ) extends RaidFinderClient with WebSocketSubscriber {
   import RaidFinderClient._
 
-  websocket.setSubscriber(Some(this))
   var isConnected: Var[Boolean] = Var(false)
   private var isStartingUp = true
 
@@ -61,11 +60,16 @@ class WebSocketRaidFinderClient(
   private val FollowedBossesStorageKey = "followedBosses"
   val state = State(allBosses = Vars.empty, followedBosses = Vars.empty)
 
-  resetBossList()
-  fetchFollowedBossesLocalStorage(FollowedBossesStorageKey).foreach { boss =>
-    follow(boss.name)
-    if (boss.isSubscribed) { subscribe(boss.name) }
-    if (boss.soundId.nonEmpty) { setNotificationSound(boss.name, boss.soundId.toOption) }
+  {
+    websocket.setSubscriber(Some(this))
+    resetBossList()
+    val storedBosses = fetchFollowedBossesLocalStorage(FollowedBossesStorageKey)
+    storedBosses.foreach { boss =>
+      follow(boss.name, sendMessage = false)
+      if (boss.isSubscribed) { subscribe(boss.name) }
+      if (boss.soundId.nonEmpty) { setNotificationSound(boss.name, boss.soundId.toOption) }
+    }
+    websocket.send(FollowRequest(bossNames = storedBosses.map(_.name)))
   }
 
   override def onWebSocketOpen(): Unit = {
@@ -105,8 +109,12 @@ class WebSocketRaidFinderClient(
     if (index < 0) None else Some(index)
   }
 
-  def follow(bossName: BossName): Unit = if (columnIndex(bossName).isEmpty) {
-    websocket.send(FollowRequest(bossNames = List(bossName)))
+  def follow(
+    bossName: BossName, sendMessage: Boolean = true
+  ): Unit = if (columnIndex(bossName).isEmpty) {
+    if (sendMessage) {
+      websocket.send(FollowRequest(bossNames = List(bossName)))
+    }
 
     // If it's not a boss we know about, create an empty column for it
     val column: RaidBossColumn = allBossesMap.getOrElse(bossName, {

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
@@ -3,6 +3,7 @@ package walfie.gbf.raidfinder.server
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.trueaccord.scalapb.json.JsonFormat
+import monix.execution.Scheduler
 import play.api.BuiltInComponents
 import play.api.http.{ContentTypes, DefaultHttpErrorHandler}
 import play.api.libs.json.Json
@@ -11,8 +12,8 @@ import play.api.mvc._
 import play.api.routing.Router
 import play.api.routing.sird._
 import play.core.server._
-import play.filters.gzip.GzipFilterComponents
 import play.filters.cors.{CORSConfig, CORSFilter}
+import play.filters.gzip.GzipFilterComponents
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import walfie.gbf.raidfinder.protocol.{RaidBossesResponse, ResponseMessage}
@@ -37,7 +38,7 @@ class Components(
 
   lazy val websocketController = new WebsocketController(
     raidFinder, translator, websocketKeepAliveInterval, metricsCollector
-  )(actorSystem, materializer)
+  )(actorSystem, materializer, Scheduler.Implicits.global)
 
   // The charset isn't necessary, but without it, Chrome displays Japanese incorrectly
   // if you try to view the JSON directly.

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -73,15 +73,13 @@ class WebsocketRaidsHandler(
 
     case r: FollowRequest =>
       // Follow bosses and their translated counterparts
-      follow(r.bossNames)
-      follow(r.bossNames.flatMap(translator.translate))
+      follow(r.bossNames ++ r.bossNames.flatMap(translator.translate))
 
       this push FollowStatusResponse(followed.keys.toSeq)
 
     case r: UnfollowRequest =>
       // Unfollow bosses and their translated counterparts
-      unfollow(r.bossNames)
-      unfollow(r.bossNames.flatMap(translator.translate))
+      unfollow(r.bossNames ++ r.bossNames.flatMap(translator.translate))
 
       this push FollowStatusResponse(followed.keys.toSeq)
   }

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/actor/WebsocketRaidsHandler.scala
@@ -18,10 +18,9 @@ class WebsocketRaidsHandler(
   translator:        BossNameTranslator,
   keepAliveInterval: Option[FiniteDuration],
   metricsCollector:  MetricsCollector
-) extends Actor {
+)(implicit scheduler: Scheduler) extends Actor {
   import WebsocketRaidsHandler.SerializedKeepAliveMessage
 
-  implicit val scheduler = Scheduler(context.system.dispatcher)
   implicit val implicitTranslator: BossNameTranslator = translator
 
   // On connect, send current version
@@ -124,7 +123,7 @@ object WebsocketRaidsHandler {
     translator:        BossNameTranslator,
     keepAliveInterval: Option[FiniteDuration],
     metricsCollector:  MetricsCollector
-  ): Props = Props {
+  )(implicit scheduler: Scheduler): Props = Props {
     new WebsocketRaidsHandler(out, raidFinder, translator, keepAliveInterval, metricsCollector)
   }.withDeploy(Deploy.local)
 }


### PR DESCRIPTION
Adds a short delay between initial websocket messages sent by the client.

By default, ActorFlow has a small 16-element buffer for outgoing
websocket messages, and will drop messages. Adding a short delay between
the initial websocket request messages gives the server some more time
to send the backfill raid tweets.

An alternative is to increase the buffer size, but it's not recommended
since it's a constant value per websocket connection and I'm not going 
to increase server-side memory usage for this.

Another alternative is to batch raid tweet messages, which is probably
the better idea, but it would be a significant change.

Fixes #93
