### PR TITLE
Ignore daily refresh tweets

### DIFF
--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import walfie.gbf.raidfinder.domain
 import walfie.gbf.raidfinder.protocol._
 import walfie.gbf.raidfinder.protocol.syntax.ResponseOps
-import walfie.gbf.raidfinder.RaidFinder
+import walfie.gbf.raidfinder.{RaidFinder, StatusParser}
 import walfie.gbf.raidfinder.server.{ImageBasedBossNameTranslator => translator}
 import walfie.gbf.raidfinder.server.persistence._
 import walfie.gbf.raidfinder.server.syntax.ProtocolConverters._
@@ -117,12 +117,14 @@ object Application {
     storage
       .get[RaidBossesItem](key)
       .fold(Seq.empty[domain.RaidBoss])(_.raidBosses.map(_.toDomain))
+      .filter(boss => StatusParser.isValidName(boss.name))
   }
 
   def getCachedTranslationData(storage: ProtobufStorage, key: String): Seq[translator.TranslationData] = {
     storage
       .get[TranslationDataItem](key)
       .fold(Seq.empty[translator.TranslationData])(_.data.map(_.toDomain))
+      .filter(data => StatusParser.isValidName(data.name))
   }
 
   def handleShutdown(mode: Mode.Mode, shutdown: () => Unit) = {

--- a/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
@@ -6,8 +6,8 @@ import scala.util.Try
 
 object StatusParser {
   /** Regexes to match raid request tweets */
-  val RaidRegexJapanese = "((?s).*)参加者募集！参戦ID：([0-9A-F]+)\n(.+)\n?.*".r
-  val RaidRegexEnglish = "((?s).*)I need backup!Battle ID: ([0-9A-F]+)\n(.+)\n?.*".r
+  val RaidRegexJapanese = "((?s).*)参加者募集！参戦ID：([0-9A-F]+)\n(.+)\n?(.*)".r
+  val RaidRegexEnglish = "((?s).*)I need backup!Battle ID: ([0-9A-F]+)\n(.+)\n?(.*)".r
 
   /**
     * Regex to get boss level from full name
@@ -20,14 +20,15 @@ object StatusParser {
     """<a href="http://granbluefantasy.jp/" rel="nofollow">グランブルー ファンタジー</a>"""
 
   def isValidName(name: BossName): Boolean = !name.contains("http")
+  private def isValidUrl(url: String): Boolean = url.isEmpty || url.matches("https?://[^ ].*")
 
   def parse(status: Status): Option[RaidInfo] = status.getText match {
     case _ if status.getSource != GranblueSource => None
 
-    case RaidRegexJapanese(extraText, raidId, boss) if isValidName(boss) =>
+    case RaidRegexJapanese(extraText, raidId, boss, url) if isValidName(boss) && isValidUrl(url) =>
       Some(TweetParts(status, extraText, raidId, boss).toRaidInfo(Language.Japanese))
 
-    case RaidRegexEnglish(extraText, raidId, boss) if isValidName(boss) =>
+    case RaidRegexEnglish(extraText, raidId, boss, url) if isValidName(boss) && isValidUrl(url) =>
       Some(TweetParts(status, extraText, raidId, boss).toRaidInfo(Language.English))
 
     case _ => None

--- a/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
@@ -20,7 +20,7 @@ object StatusParser {
     """<a href="http://granbluefantasy.jp/" rel="nofollow">グランブルー ファンタジー</a>"""
 
   def isValidName(name: BossName): Boolean = !name.contains("http")
-  private def isValidUrl(url: String): Boolean = url.isEmpty || url.matches("https?://[^ ].*")
+  private def isValidUrl(url: String): Boolean = url.isEmpty || url.matches("https?://[^ ]+")
 
   def parse(status: Status): Option[RaidInfo] = status.getText match {
     case _ if status.getSource != GranblueSource => None

--- a/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/StatusParser.scala
@@ -19,13 +19,15 @@ object StatusParser {
   val GranblueSource =
     """<a href="http://granbluefantasy.jp/" rel="nofollow">グランブルー ファンタジー</a>"""
 
+  def isValidName(name: BossName): Boolean = !name.contains("http")
+
   def parse(status: Status): Option[RaidInfo] = status.getText match {
     case _ if status.getSource != GranblueSource => None
 
-    case RaidRegexJapanese(extraText, raidId, boss) =>
+    case RaidRegexJapanese(extraText, raidId, boss) if isValidName(boss) =>
       Some(TweetParts(status, extraText, raidId, boss).toRaidInfo(Language.Japanese))
 
-    case RaidRegexEnglish(extraText, raidId, boss) =>
+    case RaidRegexEnglish(extraText, raidId, boss) if isValidName(boss) =>
       Some(TweetParts(status, extraText, raidId, boss).toRaidInfo(Language.English))
 
     case _ => None

--- a/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -150,6 +150,16 @@ class StatusParserSpec extends StatusParserSpecHelpers {
     val haiku = "#GranblueHaiku http://example.com/haiku.png"
     StatusParser.parse(mockStatus(text = haiku)) shouldBe None
   }
+
+  "return None if boss name contains http" in {
+    // Ignore tweets made via the daily Twitter refresh
+    // https://github.com/walfie/gbf-raidfinder/issues/98
+    val text = """
+      |救援依頼 参加者募集！参戦ID：114514810
+      |Lv100 ケルベロス スマホRPGは今これをやってるよ。今の推しキャラはこちら！　ゲーム内プロフィール→　https://t.co/5Xgohi9wlE https://t.co/Xlu7lqQ3km
+      """.stripMargin.trim
+    StatusParser.parse(mockStatus(text = text)) shouldBe None
+  }
 }
 
 trait StatusParserSpecHelpers extends FreeSpec with MockitoSugar {

--- a/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -180,6 +180,16 @@ class StatusParserSpec extends StatusParserSpecHelpers {
         """.stripMargin.trim
       StatusParser.parse(mockStatus(text = text)) shouldBe None
     }
+
+    "image URL has extra text after" in {
+      // First two lines are user input
+      val text = """
+        |救援依頼 参加者募集！参戦ID：114514810
+        |Lv100 ケルベロス
+        |https://t.co/5Xgohi9wlE https://t.co/Xlu7lqQ3km
+        """.stripMargin.trim
+      StatusParser.parse(mockStatus(text = text)) shouldBe None
+    }
   }
 }
 

--- a/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
+++ b/stream/src/test/scala/walfie/gbf/raidfinder/StatusParserSpec.scala
@@ -134,6 +134,15 @@ class StatusParserSpec extends StatusParserSpecHelpers {
     StatusParser.parse(status) should not be empty
   }
 
+  "parse a status with a newline at the end" in {
+    val text = """
+      |INSERT CUSTOM MESSAGE HERE 参加者募集！参戦ID：ABCD1234
+      |Lv60 オオゾラッコ""".stripMargin.trim + "\n"
+    val status = mockStatus(text = text)
+
+    StatusParser.parse(status) should not be empty
+  }
+
   "parse a status without media entities" in {
     val status = mockStatus(mediaEntities = Array.empty)
 
@@ -146,19 +155,31 @@ class StatusParserSpec extends StatusParserSpecHelpers {
     StatusParser.parse(mockStatus(source = "TweetDeck")) shouldBe None
   }
 
-  "return None invalid text" in {
-    val haiku = "#GranblueHaiku http://example.com/haiku.png"
-    StatusParser.parse(mockStatus(text = haiku)) shouldBe None
-  }
+  "return None invalid text" - {
+    "haiku" in {
+      val haiku = "#GranblueHaiku http://example.com/haiku.png"
+      StatusParser.parse(mockStatus(text = haiku)) shouldBe None
+    }
 
-  "return None if boss name contains http" in {
-    // Ignore tweets made via the daily Twitter refresh
-    // https://github.com/walfie/gbf-raidfinder/issues/98
-    val text = """
-      |救援依頼 参加者募集！参戦ID：114514810
-      |Lv100 ケルベロス スマホRPGは今これをやってるよ。今の推しキャラはこちら！　ゲーム内プロフィール→　https://t.co/5Xgohi9wlE https://t.co/Xlu7lqQ3km
-      """.stripMargin.trim
-    StatusParser.parse(mockStatus(text = text)) shouldBe None
+    "daily refresh" in {
+      // Ignore tweets made via the daily Twitter refresh
+      // https://github.com/walfie/gbf-raidfinder/issues/98
+      val text = """
+        |救援依頼 参加者募集！参戦ID：114514810
+        |Lv100 ケルベロス スマホRPGは今これをやってるよ。今の推しキャラはこちら！　ゲーム内プロフィール→　https://t.co/5Xgohi9wlE https://t.co/Xlu7lqQ3km
+        """.stripMargin.trim
+      StatusParser.parse(mockStatus(text = text)) shouldBe None
+    }
+
+    "another daily refresh" in {
+      // First two lines are user input
+      val text = """
+        |救援依頼 参加者募集！参戦ID：114514810
+        |Lv100 ケルベロス
+        |スマホRPGは今これをやってるよ。今の推しキャラはこちら！　ゲーム内プロフィール→　https://t.co/5Xgohi9wlE https://t.co/Xlu7lqQ3km
+        """.stripMargin.trim
+      StatusParser.parse(mockStatus(text = text)) shouldBe None
+    }
   }
 }
 


### PR DESCRIPTION
Fixes issue where people can use the daily Twitter refresh tweet to add
arbitrary tweet text as boss names.

Fixes #98