### PR TITLE
Add "Deploy to Heroku" button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: target/universal/stage/bin/gbf-raidfinder -Dhttp.port=$PORT -Dapplication.cache.redisUrl=$REDISCLOUD_URL -Dapplication.mode=prod
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 ![Screenshot](http://i.imgur.com/utjVgBV.png)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Features
 
 gbf-raidfinder is similar to manually configuring boss names as search
@@ -30,5 +32,6 @@ boss discovery and automatic translations), see
 [`/docs/implementation.md`](/docs/implementation.md).
 
 For project details (including running the app locally and deploying to
-Heroku), see [`/docs/project.md`](/docs/project.md).
+Heroku), see [`/docs/project.md`](/docs/project.md) and
+[`/docs/heroku.md`](/docs/heroku.md).
 

--- a/app.json
+++ b/app.json
@@ -5,10 +5,10 @@
   "logo": "https://cdn.rawgit.com/walfie/gbf-raidfinder/master/client/src/main/resources/public/icons/android-chrome-192x192.png",
   "keywords": ["gbf", "granblue", "granblue fantasy"],
   "env": {
-    "oauth.accessToken": { "description": "Twitter access token" },
-    "oauth.accessTokenSecret": { "description": "Twitter access token secret" },
     "oauth.consumerKey": { "description": "Twitter consumer key (API Key)" },
-    "oauth.consumerSecret": { "description": "Twitter consumer secret (API Secret)" }
+    "oauth.consumerSecret": { "description": "Twitter consumer secret (API Secret)" },
+    "oauth.accessToken": { "description": "Twitter access token" },
+    "oauth.accessTokenSecret": { "description": "Twitter access token secret" }
   },
   "addons": [
     "rediscloud:30"

--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "gbf-raidfinder",
+  "description": "A TweetDeck-like site for streaming Granblue raid tweets",
+  "repository": "https://github.com/walfie/gbf-raidfinder",
+  "logo": "https://cdn.rawgit.com/walfie/gbf-raidfinder/master/client/src/main/resources/public/icons/android-chrome-192x192.png",
+  "keywords": ["gbf", "granblue", "granblue fantasy"],
+  "env": {
+    "oauth.accessToken": { "description": "Twitter access token" },
+    "oauth.accessTokenSecret": { "description": "Twitter access token secret" },
+    "oauth.consumerKey": { "description": "Twitter consumer key (API Key)" },
+    "oauth.consumerSecret": { "description": "Twitter consumer secret (API Secret)" }
+  },
+  "addons": [
+    "rediscloud:30"
+  ]
+}
+

--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -1,0 +1,50 @@
+# Heroku Deployment
+
+gbf-raidfinder runs comfortably on Heroku's free tier, for about ~5000
+concurrent users. After the 5.5k user mark, performance starts to degrade,
+due to Heroku's router not being able to keep up.
+
+The app needs Twitter API credentials to connect to the streaming API.
+You can create a new app at [apps.twitter.com](https://apps.twitter.com)
+(You can enter whatever name/description/website you want, it doesn't
+actually matter). After you have an app, check the "Keys and Access Tokens"
+tab, and generate your access token/secret.
+
+Although Heroku is free, it's recommended to add a credit card so Heroku
+allows your application to run 24/7 (you won't be charged).
+
+## Quick Deploy
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/walfie/gbf-raidfinder)
+
+You can click the image above to deploy the current code in this repository
+to Heroku. This will compile and run the app (it may take several minutes
+to build the first time), and add Redis Cloud for persistence.
+
+## Manual Deploy
+
+gbf-raidfinder uses [sbt-heroku](https://github.com/heroku/sbt-heroku)
+for manual Heroku deployment. To run your own instance, you will need
+to set some environment variables and enable Redis Cloud.
+
+* Set Twitter credentials:
+
+  ```sh
+  heroku config:add oauth.consumerKey=insert
+  heroku config:add oauth.consumerSecret=your
+  heroku config:add oauth.accessToken=credentials
+  heroku config:add oauth.accessTokenSecret=here
+  ```
+
+* Add the [Redis Cloud](https://elements.heroku.com/addons/rediscloud)
+  add-on to your project
+
+* Change the following line in [`/build.sbt`](/build.sbt) to point to your
+  application name (not "gbf-raidfinder")
+
+  ```scala
+  herokuAppName in Compile := "gbf-raidfinder",
+  ```
+
+* Run `sbt stage deployHeroku`
+

--- a/docs/project.md
+++ b/docs/project.md
@@ -42,7 +42,9 @@ restarts.
 
 ### Run Locally
 
-* Ensure you have [jre](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html), [sbt](http://www.scala-sbt.org/), and [python 2.x](https://www.python.org/downloads/) installed prior to running the app.
+* Ensure you have [jre](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html),
+[sbt](http://www.scala-sbt.org/), and [python 2.x](https://www.python.org/downloads/)
+(if using Windows) installed prior to running the app.
 
 The Play application can be run with `sbt run` and going to
 [localhost:9000](http://localhost:9000). This will also compile the
@@ -54,30 +56,7 @@ via local filesystem or some other HTTP server). If viewed via local
 filesystem, the client will connect to `gbf-raidfinder.aikats.us` instead
 of a locally-running server.
 
-## Heroku Deployment
+### Heroku Deployment
 
-gbf-raidfinder uses [sbt-heroku](https://github.com/heroku/sbt-heroku) for
-Heroku deployment. To run your own instance, you will need to set some
-environment variables and enable Redis Cloud.
-
-* Set Twitter credentials:
-
-  ```sh
-  heroku config:add oauth.consumerKey=insert
-  heroku config:add oauth.consumerSecret=your
-  heroku config:add oauth.accessToken=credentials
-  heroku config:add oauth.accessTokenSecret=here
-  ```
-
-* Add the [Redis Cloud](https://elements.heroku.com/addons/rediscloud)
-  add-on to your project
-
-* Change the following line in [`/build.sbt`](/build.sbt) to point to your
-  application name (not "gbf-raidfinder")
-
-  ```scala
-  herokuAppName in Compile := "gbf-raidfinder",
-  ```
-
-* Run `sbt stage deployHeroku`
+See [`docs/heroku.md`](heroku.md) for instructions on deploying to Heroku.
 


### PR DESCRIPTION
For quick deployment to Heroku, especially for non-developers. Create a twitter app to get API credentials, click the button, copy/paste some API keys, and you have your own running instance of gbf-raidfinder.

Successfully deployed one to https://granblue-raidfinder.herokuapp.com/ using the button.