### PR TITLE
Add 30-day max TTL for bosses, regardless of level

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -26,7 +26,11 @@ application {
     cacheKey = bosses
     ttl = 12h
     flushInterval = 60s
-    levelThreshold = 100 # Bosses higher than this level (inclusive) are not removed from cache
+
+    # Bosses higher than this level (inclusive) are not removed from cache
+    # unless maxTtl has been reached.
+    levelThreshold = 100
+    maxTtl = 30d
   }
 
   cache {

--- a/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/KnownBossesMap.scala
@@ -16,7 +16,10 @@ trait KnownBossesMap {
     * @param minDate Remove bosses that haven't been seen since this date
     * @param levelThreshold Bosses higher than this level (inclusive) will not be removed
     */
-  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]]
+  def purgeOldBosses(
+    minDate:        Date,
+    levelThreshold: Option[Int]
+  ): Future[Map[BossName, RaidBoss]]
 }
 
 object KnownBossesObserver {
@@ -59,10 +62,10 @@ class KnownBossesObserver(
   def get(): Map[BossName, RaidBoss] = agent.get()
   def purgeOldBosses(
     minDate:        Date,
-    levelThreshold: Int
+    levelThreshold: Option[Int]
   ): Future[Map[BossName, RaidBoss]] = {
     agent.alter(_.filter {
-      case (name, boss) => boss.lastSeen.after(minDate) || boss.level >= levelThreshold
+      case (name, boss) => boss.lastSeen.after(minDate) || levelThreshold.exists(boss.level >= _)
     })
   }
 }

--- a/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
+++ b/stream/src/main/scala/walfie/gbf/raidfinder/RaidFinder.scala
@@ -14,7 +14,11 @@ trait RaidFinder[T] {
   def getRaidTweets(bossName: BossName): Observable[T]
   def newBossObservable: Observable[RaidBoss]
   def getKnownBosses(): Map[BossName, RaidBoss]
-  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]]
+  def purgeOldBosses(
+    minDate:        Date,
+    levelThreshold: Option[Int]
+  ): Future[Map[BossName, RaidBoss]]
+
   def shutdown(): Unit
 }
 
@@ -114,7 +118,11 @@ class RaidFinderImpl[T](
     knownBosses.get()
   def getRaidTweets(bossName: BossName): Observable[T] =
     partitioner.getObservable(bossName)
-  def purgeOldBosses(minDate: Date, levelThreshold: Int): Future[Map[BossName, RaidBoss]] =
+
+  def purgeOldBosses(
+    minDate:        Date,
+    levelThreshold: Option[Int]
+  ): Future[Map[BossName, RaidBoss]] =
     knownBosses.purgeOldBosses(minDate, levelThreshold)
 }
 


### PR DESCRIPTION
Currently we never clear bosses from the list if they are lv100+, but
this leads to some high-level event bosses staying around forever. This
adds a `maxTtl` that is used to purge bosses regardless of level.