### PR TITLE
Optimize serializing outbound Protobuf messages

### DIFF
--- a/protocol/shared/src/main/scala/walfie/gbf/raidfinder/protocol/package.scala
+++ b/protocol/shared/src/main/scala/walfie/gbf/raidfinder/protocol/package.scala
@@ -10,6 +10,12 @@ package object protocol {
 }
 
 package protocol {
+  class BinaryProtobuf(val value: Array[Byte]) extends AnyVal
+  object BinaryProtobuf {
+    def apply(value: Array[Byte]): BinaryProtobuf =
+      new BinaryProtobuf(value)
+  }
+
   // Doesn't support versions with no bugfix segment
   // TODO: This throws a ton of errors on linking scala.js if this extends AnyVal.
   // Should figure out why. Maybe. It's not incredibly important.

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Application.scala
@@ -34,7 +34,10 @@ object Application {
 
     // Start RaidFinder
     val raidFinder = {
-      implicit val fromRaidTweet = domain.FromRaidTweet(_.toProtocol.toMessage)
+      implicit val fromRaidTweet: domain.FromRaidTweet[BinaryProtobuf] =
+        domain.FromRaidTweet { raidTweet =>
+          BinaryProtobuf(raidTweet.toProtocol.toMessage.toByteArray)
+        }
       val initialBosses = getCachedBosses(protobufStorage, bossStorageConfig.cacheKey)
       RaidFinder.withBackfill(initialBosses = initialBosses)
     }

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/Components.scala
@@ -16,13 +16,13 @@ import play.filters.cors.{CORSConfig, CORSFilter}
 import play.filters.gzip.GzipFilterComponents
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
-import walfie.gbf.raidfinder.protocol.{RaidBossesResponse, ResponseMessage}
+import walfie.gbf.raidfinder.protocol.{RaidBossesResponse, BinaryProtobuf}
 import walfie.gbf.raidfinder.RaidFinder
 import walfie.gbf.raidfinder.server.controller._
 import walfie.gbf.raidfinder.server.syntax.ProtocolConverters.RaidBossDomainOps
 
 class Components(
-  raidFinder:                 RaidFinder[ResponseMessage],
+  raidFinder:                 RaidFinder[BinaryProtobuf],
   translator:                 BossNameTranslator,
   port:                       Int,
   mode:                       Mode,

--- a/server/src/main/scala/walfie/gbf/raidfinder/server/controller/WebsocketController.scala
+++ b/server/src/main/scala/walfie/gbf/raidfinder/server/controller/WebsocketController.scala
@@ -18,7 +18,7 @@ import walfie.gbf.raidfinder.server.util.MessageFlowTransformerUtil
 import walfie.gbf.raidfinder.server.{BossNameTranslator, MetricsCollector}
 
 class WebsocketController(
-  raidFinder:        RaidFinder[ResponseMessage],
+  raidFinder:        RaidFinder[BinaryProtobuf],
   translator:        BossNameTranslator,
   keepAliveInterval: FiniteDuration,
   metricsCollector:  MetricsCollector
@@ -42,7 +42,7 @@ class WebsocketController(
 
     val interval = if (keepAlive) Some(keepAliveInterval) else None
 
-    val transformerOpt: Option[MessageFlowTransformer[RequestMessage, ResponseMessage]] =
+    val transformerOpt: Option[MessageFlowTransformer[RequestMessage, BinaryProtobuf]] =
       if (requestedProtocols.isEmpty) {
         Some(defaultTransformer)
       } else requestedProtocols.collectFirst {


### PR DESCRIPTION
The previous code kept the messages as ScalaPB case classes until it was
time to send them to the client, meaning each raid tweet is serialized
into a `Byte[Array]` once per user. This changes it to only serialize a
raid tweet once, as it comes in from the Twitter stream.