### PR TITLE
fix raid list dialog not correctly displayed

### DIFF
--- a/client/src/main/resources/public/css/base.css
+++ b/client/src/main/resources/public/css/base.css
@@ -207,8 +207,6 @@ html, body, .gbfrf-container {
   background: #ffffff;
 
   position: absolute;
-  top: 50%;
-  transform: translate(0, -50%);
   left: 0;
   right: 0;
   margin-left: auto;


### PR DESCRIPTION
this should fix the display on both desktop and mobile

issue: https://github.com/walfie/gbf-raidfinder/issues/139

![image](https://user-images.githubusercontent.com/4152224/110139245-6aff8900-7e05-11eb-99cd-0db45a791574.png)
![image](https://user-images.githubusercontent.com/4152224/110139307-7b176880-7e05-11eb-8525-d1f95a28345d.png)
![image](https://user-images.githubusercontent.com/4152224/110139327-7f438600-7e05-11eb-887b-e858a937c294.png)

